### PR TITLE
Support Ruby 1.9.3 for TOC

### DIFF
--- a/lib/asciidoctor/pdf_renderer.rb
+++ b/lib/asciidoctor/pdf_renderer.rb
@@ -168,7 +168,7 @@ class PDFRenderer < ::Prawn::Document
       (0..-1)
     end
 
-    add_page_numbers skip: (toc_page_nums.size + 1)
+    add_page_numbers skip: (toc_page_nums.to_a.size + 1)
 
     add_outline doc, num_toc_levels, toc_page_nums
     catalog.data[:ViewerPreferences] = [:FitWindow]


### PR DESCRIPTION
The size method was introduced in Ruby 2.0.0 to Range. For rubies below
2.0.0 you'd need to make an array out of it first.
