### PR TITLE
#35 Multipage toc

### DIFF
--- a/lib/asciidoctor-pdf/converter.rb
+++ b/lib/asciidoctor-pdf/converter.rb
@@ -109,6 +109,11 @@ class Converter < ::Prawn::Document
     layout_title_page doc
 
     start_new_page
+    external_toc_size = 0
+    external_toc_size = doc.attr 'toc_lenght' if doc.attr 'toc_lenght'
+    external_toc_size.to_i.times do
+      start_new_page
+    end
     font @theme.base_font_family, size: @theme.base_font_size
     convert_content_for_block doc
 


### PR DESCRIPTION
The first commit https://github.com/DavidGamba/asciidoctor-pdf/commit/71f2711f7f0074e94176ba7ff1ec0f2213b9e7b3 is to make sure you move to the right page before moving the cursor.

The second one https://github.com/DavidGamba/asciidoctor-pdf/commit/1fa846923650fd4b7b9e0edb58ca10b6c6f7cf19 is a way to know how many pages are required for the TOC.

I couldn't find where to create those pages for the TOC to have enough space.

I hope this helps solve the issue.
