### PR TITLE
Use require_relative for ../lib/asciidoctor-pdf in bin/asciidoctor-pdf

### DIFF
--- a/bin/asciidoctor-pdf
+++ b/bin/asciidoctor-pdf
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-require File.join File.dirname(__FILE__), '../lib/asciidoctor-pdf'
+require_relative '../lib/asciidoctor-pdf'
 require 'asciidoctor/cli'
 
 options = Asciidoctor::Cli::Options.new backend: 'pdf', header_footer: true


### PR DESCRIPTION
I just tried to use the `bin/asciidoctor-pdf` command [as per this page](http://asciidoctor.org/docs/convert-asciidoc-to-pdf/) and I saw this error:

```
asciidoctor-pdf (master)⸘ ruby bin/asciidoctor-pdf ~/Projects/rails_book/rails_book.asc
/Users/ryanbigg/.rubies/ruby-2.1.3/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require': cannot load such file -- bin/../lib/asciidoctor-pdf (LoadError)
    from /Users/ryanbigg/.rubies/ruby-2.1.3/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from bin/asciidoctor-pdf:3:in `<main>'
```

I investigated it and found that the `bin/asciidoctor-pdf` code is using a more complex way of requiring a relative path. I changed it over to `require_relative` in the vague hope that it would fix it and lo and behold it did.
