### PR TITLE
theme: Allow custom page size setting

### DIFF
--- a/lib/asciidoctor-pdf/converter.rb
+++ b/lib/asciidoctor-pdf/converter.rb
@@ -165,9 +165,12 @@ class Converter < ::Prawn::Document
       info: (build_pdf_info doc),
       margin: (theme.page_margin || 36),
       page_layout: (theme.page_layout || :portrait).to_sym,
-      page_size: (theme.page_size || 'LETTER').upcase,
+      page_size: (theme.page_size || 'LETTER'),
       skip_page_creation: true,
     }
+
+    pdf_opts[:page_size] = pdf_opts[:page_size].upcase if ::String === pdf_opts[:page_size]
+
     # FIXME fix the namespace for FormattedTextFormatter
     pdf_opts[:text_formatter] ||= ::Asciidoctor::Prawn::FormattedTextFormatter.new theme: theme
     pdf_opts


### PR DESCRIPTION
To allow a custom page size to be used, we need to check if the
argument passed in the theme is a String, for which we ought to upcase
to use in Prawn converted, or keep the custom value to be passed over
it.

This has been tested using a custom theme with:

,----
| ...
| page:
|   ...
|   size: [508, 635]
|   ...
| ...
`----

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>