### PR TITLE
resolves #56 fix xref to sections

### DIFF
--- a/lib/asciidoctor-pdf/converter.rb
+++ b/lib/asciidoctor-pdf/converter.rb
@@ -853,25 +853,7 @@ class Converter < ::Prawn::Document
   end
 
   def convert_inline_anchor node
-    target = node.target
     case node.type
-    when :xref
-      refid = (node.attr 'refid') || target
-      # NOTE we lookup text in converter because DocBook doesn't need this logic
-      if (text = node.text || (node.document.references[:ids][refid] || %([#{refid}])))
-        # FIXME shouldn't target be refid? logic seems confused here
-        %(<link anchor="#{target}">#{text}</link>)
-      # FIXME hack for bibliography references
-      # should be able to reenable once we parse inline destinations
-      else
-        %((see [#{refid}]))
-      end
-    when :ref
-      #%(<a id="#{target}"></a>)
-      ''
-    when :bibref
-      #%(<a id="#{target}"></a>[#{target}])
-      %([#{target}])
     when :link
       attrs = []
       #attrs << %( id="#{node.id}") if node.id
@@ -881,11 +863,39 @@ class Converter < ::Prawn::Document
       #attrs << %( title="#{node.attr 'title'}") if node.attr? 'title'
       attrs << %( target="#{node.attr 'window'}") if node.attr? 'window'
       if (node.document.attr? 'showlinks') && !(node.has_role? 'bare')
+        target = node.target
         # TODO cleanup look, perhaps put target in smaller text
         %(<link href="#{target}"#{attrs.join}>#{node.text}</a> (#{target}))
       else
         %(<link href="#{target}"#{attrs.join}>#{node.text}</a>)
       end
+    when :xref
+      target = node.target
+      # NOTE the presence of path indicates an inter-document xref
+      if (path = node.attr 'path', nil, false)
+        %(<link href="#{target}">#{node.text || path}</a>)
+      else
+        fragment = node.attr 'fragment', target, false
+        refid = node.attr 'refid', target, false
+        # NOTE we know the destination exists if it's found in the id table
+        if (reftext = node.document.references[:ids][refid])
+          %(<link anchor="#{fragment}">#{node.text || reftext}</link>)
+        else
+          source = $VERBOSE ? %( in source:\n#{node.parent.lines * "\n"}) : nil
+          warn %(asciidoctor: WARNING: reference '#{refid}' not found#{source})
+          %[(see #{node.text || %([#{refid}])})]
+        end
+      end
+    when :ref
+      # FIXME add destination to PDF document
+      #target = node.target
+      #%(<a id="#{target}"></a>)
+      ''
+    when :bibref
+      # FIXME add destination to PDF document
+      #target = node.target
+      #%(<a id="#{target}"></a>[#{target}])
+      %([#{node.target}])
     else
       warn %(asciidoctor: WARNING: unknown anchor type: #{node.type.inspect})
     end


### PR DESCRIPTION
- retrieve the anchor name from the fragment attribute
- handle inter-document xrefs by consulting the path attribute
- honor the reftext of the destination
- warn if an xref cannot be resolved