### PR TITLE
resolves #139 allow theme to set font size & family of table cells

### DIFF
--- a/lib/asciidoctor-pdf/converter.rb
+++ b/lib/asciidoctor-pdf/converter.rb
@@ -847,6 +847,7 @@ class Converter < ::Prawn::Document
     num_cols = node.columns.size
     table_header = false
 
+    # FIXME this is a mess!
     unless (page_bg_color = @theme.page_background_color) && page_bg_color != 'transparent'
       page_bg_color = nil
     end
@@ -875,10 +876,12 @@ class Converter < ::Prawn::Document
       rows.each do |cell|
         row_data << {
           content: cell.text,
-          text_color: (@theme.table_head_font_color || @font_color),
+          inline_format: [{ normalize: true }],
           background_color: head_bg_color,
-          inline_format: true,
-          font_style: :bold,
+          text_color: (@theme.table_head_font_color || @theme.table_font_color || @font_color),
+          size: (@theme.table_head_font_size || @theme.table_font_size),
+          font: (@theme.table_head_font_family || @theme.table_font_family),
+          font_style: (@theme.table_head_font_style || :bold).to_sym,
           colspan: cell.colspan || 1,
           rowspan: cell.rowspan || 1,
           align: (cell.attr 'halign').to_sym,
@@ -894,8 +897,10 @@ class Converter < ::Prawn::Document
       rows.each do |cell|
         cell_data = {
           content: cell.text,
-          text_color: (@theme.table_body_font_color || @font_color),
           inline_format: [{ normalize: true }],
+          text_color: (@theme.table_body_font_color || @font_color),
+          size: @theme.table_font_size,
+          font: @theme.table_font_family,
           colspan: cell.colspan || 1,
           rowspan: cell.rowspan || 1,
           align: (cell.attr 'halign').to_sym,


### PR DESCRIPTION
- support font size, family and style for cells in the table head row
- support font size and family for cells in table body rows
- normalize endlines of cell content in table head row