### PR TITLE
resolves #134 allow page background image to be specified

### DIFF
--- a/lib/asciidoctor-pdf/prawn_ext.rb
+++ b/lib/asciidoctor-pdf/prawn_ext.rb
@@ -1,3 +1,4 @@
 # the following modules / classes are organized under the Asciidoctor::Prawn namespace
+require_relative 'prawn_ext/images'
 require_relative 'prawn_ext/extensions'
 require_relative 'prawn_ext/formatted_text/formatter'

--- a/lib/asciidoctor-pdf/prawn_ext/extensions.rb
+++ b/lib/asciidoctor-pdf/prawn_ext/extensions.rb
@@ -318,6 +318,13 @@ module Extensions
     end
   end
 
+  # Fills the absolute bounding box with the specified fill color. Before
+  # returning from this method, the original fill color on the document is
+  # restored.
+  def fill_absolute_bounds f_color = fill_color
+    canvas { fill_bounds f_color }
+  end
+
   # Fills the current bounds using the specified fill color and strokes the
   # bounds using the specified stroke color. Sets the line with if specified
   # in the options. Before returning from this method, the original fill

--- a/lib/asciidoctor-pdf/prawn_ext/images.rb
+++ b/lib/asciidoctor-pdf/prawn_ext/images.rb
@@ -1,0 +1,22 @@
+module Asciidoctor
+module Prawn
+module Images
+  # Dispatch to suitable image method in Prawn based on file extension.
+  def image file, opts = {}
+    if (::File.extname file).downcase == '.svg'
+      opts[:at] ||= bounds.top_left
+      svg ::IO.read(file), opts
+    else
+      _builtin_image file, opts
+    end
+  end
+end
+end
+end
+
+module Prawn
+class Document
+  alias :_builtin_image :image
+  include ::Asciidoctor::Prawn::Images
+end
+end

--- a/lib/asciidoctor-pdf/theme_loader.rb
+++ b/lib/asciidoctor-pdf/theme_loader.rb
@@ -14,11 +14,16 @@ class ThemeLoader
     # if .yml extension is given, assume it's a full file name
     if theme_name.end_with? '.yml'
       # FIXME restrict to jail!
+      # QUESTION why are we not using expand_path in this case?
       theme_path ? (::File.join theme_path, theme_name) : theme_name
     else
       # QUESTION should we append '-theme.yml' or just '.yml'?
       ::File.expand_path %(#{theme_name}-theme.yml), (theme_path || ThemesDir)
     end
+  end
+
+  def self.resolve_theme_asset asset_path, theme_path = nil
+    ::File.expand_path asset_path, (theme_path || ThemesDir)
   end
 
   def self.load_theme theme_name = nil, theme_path = nil


### PR DESCRIPTION
- allow background image to be specified for all pages
- allow background image to be specified for title page
- resolve background image relative to pdf-stylesdir (theme dir)
- allow background color to be specified for title page
- add fill_absolute_bounds convenience method