### PR TITLE
resolves #155 support CMYK color values

### DIFF
--- a/data/themes/default-theme.yml
+++ b/data/themes/default-theme.yml
@@ -28,7 +28,13 @@ page:
   # size can be a named size (e.g., A4) or custom dimensions (e.g., [8.25in, 11.69in])
   size: Letter
 base:
+  # color as hex string (leading # is optional)
   font_color: 333333
+  # color as RGB array
+  #font_color: [51, 51, 51]
+  # color as CMYK array (approximated)
+  #font_color: [0, 0, 0, 0.92]
+  #font_color: [0, 0, 0, 92%]
   font_family: NotoSerif
   # choose one of these font_size/line_height_length combinations
   #font_size: 14

--- a/lib/asciidoctor-pdf/converter.rb
+++ b/lib/asciidoctor-pdf/converter.rb
@@ -1185,6 +1185,7 @@ class Converter < ::Prawn::Document
 
   def convert_inline_callout node
     if (conum_color = @theme.conum_font_color)
+      # NOTE CMYK value gets flattened here, but is restored by formatted text parser
       %(<color rgb="#{conum_color}">#{conum_glyph node.text.to_i}</color>)
     else
       node.text
@@ -1196,6 +1197,7 @@ class Converter < ::Prawn::Document
       #text = node.document.footnotes.find {|fn| fn.index == index }.text
       %( [#{node.text}])
     elsif node.type == :xref
+      # NOTE footnote reference not found
       %( <color rgb="FF0000">[#{node.text}]</color>)
     end
   end
@@ -1437,6 +1439,7 @@ class Converter < ::Prawn::Document
     if (anchor = opts.delete :anchor)
       # FIXME won't work if inline_format is true; should instead pass through as attribute w/ link color set
       if (link_color = opts.delete :link_color)
+        # NOTE CMYK value gets flattened here, but is restored by formatted text parser
         string = %(<a anchor="#{anchor}"><color rgb="#{link_color}">#{string}</color></a>)
       else
         string = %(<a anchor="#{anchor}">#{string}</a>)
@@ -1522,6 +1525,7 @@ class Converter < ::Prawn::Document
       # NOTE we do some cursor hacking here so the dots don't affect vertical alignment
       start_page_number = page_number
       start_cursor = cursor
+      # NOTE CMYK value gets flattened here, but is restored by formatted text parser
       typeset_text %(<a anchor="#{sect_anchor = (sect.attr 'anchor') || sect.id}"><color rgb="#{toc_font_color}">#{sect_title}</color></a>), line_metrics, inline_format: true
       # we only write the label if this is a dry run
       unless scratch?

--- a/lib/asciidoctor-pdf/prawn_ext/extensions.rb
+++ b/lib/asciidoctor-pdf/prawn_ext/extensions.rb
@@ -347,8 +347,8 @@ module Extensions
   # color, stroke color and line width on the document are restored.
   #
   def fill_and_stroke_bounds f_color = fill_color, s_color = stroke_color, options = {}
-    no_fill = (f_color.nil? || f_color.to_s == 'transparent')
-    no_stroke = (s_color.nil? || s_color.to_s == 'transparent')
+    no_fill = !f_color || f_color == 'transparent'
+    no_stroke = !s_color || s_color == 'transparent'
     return if no_fill && no_stroke
     save_graphics_state do
       radius = options[:radius] || 0


### PR DESCRIPTION
- parse CMYK color values in theme
- parse CMYK color values in formatted text
- avoid redundant processing of color values when loading theme
- mixin color types into color values
- show example of CMYK value in default theme
- code formatting