### PR TITLE
resolves #170 allow font color of outline list marker to be set by theme 

### DIFF
--- a/data/themes/default-theme.yml
+++ b/data/themes/default-theme.yml
@@ -188,6 +188,7 @@ outline_list:
   indent: $horizontal_rhythm * 1.5
   # NOTE item_spacing applies to list items that do not have complex content
   item_spacing: $vertical_rhythm / 2
+  #marker_font_color: 404040
 table:
   background_color: ffffff
   #head_background_color: <hex value>

--- a/lib/asciidoctor-pdf/converter.rb
+++ b/lib/asciidoctor-pdf/converter.rb
@@ -688,6 +688,7 @@ class Converter < ::Prawn::Document
       bounding_box [start_position, cursor], width: marker_width do
         layout_prose marker,
           align: :right,
+          color: (@theme.outline_list_marker_font_color || @font_color),
           normalize: false,
           inline_format: false,
           margin: 0,
@@ -1545,7 +1546,7 @@ class Converter < ::Prawn::Document
   end
 
   def layout_toc_level sections, num_levels, line_metrics, dot_width, num_front_matter_pages = 0
-    toc_dot_color = @theme.toc_dot_leader_color
+    toc_dot_color = @theme.toc_dot_leader_font_color || @theme.toc_font_color || @font_color
     sections.each do |sect|
       theme_font :toc, level: (sect.level + 1) do
         sect_title = @text_transform ? (transform_text sect.numbered_title, @text_transform) : sect.numbered_title

--- a/lib/asciidoctor-pdf/converter.rb
+++ b/lib/asciidoctor-pdf/converter.rb
@@ -889,7 +889,7 @@ class Converter < ::Prawn::Document
         end
 
         pad_box @theme.code_padding do
-          typeset_formatted_text source_chunks, (calc_line_metrics @theme.code_line_height), color: @theme.code_font_color
+          typeset_formatted_text source_chunks, (calc_line_metrics @theme.code_line_height), color: (@theme.code_font_color || @font_color)
         end
       end
     end
@@ -951,7 +951,7 @@ class Converter < ::Prawn::Document
         if line.size > 0 && (end_text = line.last[:text]) && !(end_text.end_with? ' ')
           line.last[:text] = %(#{end_text} )
         end
-        line << { text: (conums * ' '), color: conum_color }
+        line << conum_color ? { text: (conums * ' '), color: conum_color } : { text: (conums * ' ') }
       end
       line << { text: EOL } unless line_num == last_line_num
       line
@@ -1676,7 +1676,7 @@ class Converter < ::Prawn::Document
       trim_content_height = trim_height - trim_padding[0] - trim_padding[2] - trim_line_metrics.padding_top
       trim_left = page_margin_left
       trim_width = page_width - trim_left - page_margin_right
-      trim_font_color = @theme.header_font_color
+      trim_font_color = @theme.header_font_color || @font_color
       trim_bg_color = @theme.header_background_color
       trim_border_width = @theme.header_border_width || @theme.base_border_width
       trim_border_color = @theme.header_border_color
@@ -1689,7 +1689,7 @@ class Converter < ::Prawn::Document
       trim_content_height = trim_height - trim_padding[0] - trim_padding[2] - trim_line_metrics.padding_top
       trim_left = page_margin_left
       trim_width = page_width - trim_left - page_margin_right
-      trim_font_color = @theme.footer_font_color
+      trim_font_color = @theme.footer_font_color || @font_color
       trim_bg_color = @theme.footer_background_color
       trim_border_width = @theme.footer_border_width || @theme.base_border_width
       trim_border_color = @theme.footer_border_color

--- a/lib/asciidoctor-pdf/converter.rb
+++ b/lib/asciidoctor-pdf/converter.rb
@@ -1217,7 +1217,7 @@ class Converter < ::Prawn::Document
       # NOTE CMYK value gets flattened here, but is restored by formatted text parser
       %(<color rgb="#{conum_color}">#{conum_glyph node.text.to_i}</color>)
     else
-      node.text
+      conum_glyph node.text.to_i
     end
   end
 


### PR DESCRIPTION
- add outline_list_marker_font_color setting to control marker font color
- rename toc_dot_leader color to toc_dot_leader_font_color for consistency
- use glyph for conum even when conum font color is not set
- always fallback to base font color if not set