### PR TITLE
resolves #68 upgrade Prawn

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,6 @@
 source 'https://rubygems.org'
 
+gem 'prawn', '1.3.0' if (Gem::Version.new RUBY_VERSION) < (Gem::Version.new '2.0.0')
+
 # Look in asciidoctor-pdf.gemspec for runtime and development dependencies
 gemspec

--- a/README.adoc
+++ b/README.adoc
@@ -39,7 +39,7 @@ See the milestone v1.5.0 in the {uri-project-issues}[issue tracker] for details.
 
 == Prawn, the majestic PDF generator
 
-{uri-project}[{project-name}] is made possible by an amazing Ruby Gem named Prawn.
+{uri-project}[{project-name}] is made possible by an amazing Ruby gem named Prawn.
 And what a gem it is!
 
 {uri-prawn}[Prawn] is a nimble PDF writer for Ruby.
@@ -93,7 +93,17 @@ See <<WORKLOG.adoc#,WORKLOG>>.
 
 == Prerequisites
 
-All that's needed is Ruby (1.9.3 or better; 2.2.x recommended) and a few Ruby Gems, which we explain how to install in the next section.
+All that's needed is Ruby (1.9.3 or above; 2.2.x recommended) and a few Ruby gems, which we explain how to install in the next section.
+
+[WARNING]
+====
+Prawn 2.0.0 and above requires Ruby >= 2.0.0 at installation (though it still works with Ruby 1.9.3 once you get beyond installation).
+If you need to use Asciidoctor PDF with Ruby 1.9.3, you must first install Prawn 1.3.0 using:
+
+  $ gem install prawn --version 1.3.0
+
+You can then proceed with installation of Asciidoctor PDF.
+====
 
 To check you have Ruby available, use the `ruby` command to query the version installed:
 

--- a/asciidoctor-pdf.gemspec
+++ b/asciidoctor-pdf.gemspec
@@ -37,8 +37,10 @@ An extension for Asciidoctor that converts AsciiDoc documents to PDF using the P
   #s.add_development_dependency 'rdoc', '~> 4.1.0'
 
   s.add_runtime_dependency 'asciidoctor', '~> 1.5.0'
-  s.add_runtime_dependency 'prawn', '1.2.1'
-  s.add_runtime_dependency 'prawn-table', '0.1.1'
+  #s.add_runtime_dependency 'prawn', '2.0.1'
+  # Prawn 2.x requires Ruby 2.x, so cast a wider net
+  s.add_runtime_dependency 'prawn', '>= 1.3.0', '< 3.0.0'
+  s.add_runtime_dependency 'prawn-table', '0.2.1'
   s.add_runtime_dependency 'prawn-templates', '0.0.3'
   s.add_runtime_dependency 'prawn-svg', '0.18.0'
   s.add_runtime_dependency 'prawn-icon', '0.6.4'

--- a/docs/theming-guide.adoc
+++ b/docs/theming-guide.adoc
@@ -462,7 +462,7 @@ title_page:
 You can select from <<built-in-fonts,built-in PDF fonts>>, <<bundled-fonts,fonts bundled with Asciidoctor PDF>> or <<custom-fonts,custom fonts>> loaded from TrueType font (TTF) files.
 If you want to use custom fonts, you must first declare them in your theme file.
 
-=== Built-in fonts
+=== Built-in (AFM) fonts
 
 The names of the built-in fonts (for general-purpose text) are as follows:
 
@@ -490,13 +490,20 @@ base:
   font_family: Times-Roman
 ----
 
-However, when you use a built-in font, the characters that you use in your document are limited to the WINANSI (http://en.wikipedia.org/wiki/Windows-1252[Windows-1252]) code set.
+However, when you use a built-in font, the characters that you use in your document are limited to the characters in the WINANSI (http://en.wikipedia.org/wiki/Windows-1252[Windows-1252]) code set.
 WINANSI includes most of the characters needed for writing in Western languages (English, French, Spanish, etc).
 For anything outside of that, PDF is BYOF (Bring Your Own Font).
 
 Even though the built-in fonts require the content to be encoded in WINANSI, _you still type your AsciiDoc document in UTF-8_.
 Asciidoctor PDF encodes the content into WINANSI when building the PDF.
-Any characters in your AsciiDoc document that cannot be encoded will be replaced with an underscore (`_`).
+
+.WINANSI encoding behavior
+****
+If you're using Prawn 1.3.0 with one of the built-in fonts, any characters in your AsciiDoc document that cannot be encoded to WINANSI will be replaced with an underscore glyph (`_`).
+If you're using Prawn 2.0.0 or above with one of the built-in fonts, if your AsciiDoc document contains a character that cannot be encoded to WINANSI, a warning will be issued and conversion will halt.
+
+For more information about how Prawn handles character encodings for built-in fonts, see https://github.com/prawnpdf/prawn/blob/master/CHANGELOG.md#vastly-improved-handling-of-encodings-for-pdf-built-in-afm-fonts[this note in the Prawn CHANGELOG].
+****
 
 === Bundled fonts
 

--- a/lib/asciidoctor-pdf/converter.rb
+++ b/lib/asciidoctor-pdf/converter.rb
@@ -122,7 +122,7 @@ class Converter < ::Prawn::Document
       elsif @page_bg_color && @page_bg_color != 'FFFFFF'
         fill_absolute_bounds @page_bg_color
       end
-    end
+    end if respond_to? :on_page_create
 
     layout_cover_page :front, doc
     layout_title_page doc


### PR DESCRIPTION
- set Prawn version to >= 1.3.0 and < 3.0.0
- convince Bundler to install Prawn 1.3.0 if Ruby version < 2.0.0
- resolve missing on_page_create method
  - add check for on_page_create method since its status is questionable