### PR TITLE
resolves #215 fix dry run calculation of block height (again)

### DIFF
--- a/lib/asciidoctor-pdf/prawn_ext/extensions.rb
+++ b/lib/asciidoctor-pdf/prawn_ext/extensions.rb
@@ -648,14 +648,18 @@ module Extensions
     scratch = get_scratch_document
     scratch.start_new_page
     start_page_number = scratch.page_number
-    # QUESTION is it enough to just set the padding or do we need to clone the bounds?
-    default_bounds = scratch.bounds
-    scratch.bounds = bounds.deep_copy.tap {|b| b.instance_variable_set :@document, scratch }
     start_y = scratch.y
+    if (left_padding = bounds.total_left_padding) > 0
+      scratch.bounds.add_left_padding left_padding
+    end
+    if (right_padding = bounds.total_right_padding) > 0
+      scratch.bounds.add_right_padding right_padding
+    end
     scratch.font font_family, style: font_style, size: font_size do
       scratch.instance_exec(&block)
     end
-    scratch.bounds = default_bounds
+    scratch.bounds.subtract_left_padding left_padding if left_padding > 0
+    scratch.bounds.subtract_right_padding right_padding if right_padding > 0
     whole_pages = scratch.page_number - start_page_number
     [(whole_pages * bounds.height + (start_y - scratch.y)), whole_pages, (start_y - scratch.y)]
   end


### PR DESCRIPTION
- turns out, setting bounds directly doesn't work across pages
- instead, set padding on bounds explicitly around dry run