### PR TITLE
resolves #247 add support for the Rouge source highlighter

### DIFF
--- a/lib/asciidoctor-pdf/prawn_ext/coderay_encoder.rb
+++ b/lib/asciidoctor-pdf/prawn_ext/coderay_encoder.rb
@@ -69,10 +69,10 @@ class CodeRayEncoder < ::CodeRay::Encoders::Encoder
   }
 
   EOL = %(\n)
+  NoBreakSpace = %(\u00a0)
   InnerIndent = %(\n )
-  # \u200b is zero-width space
-  IndentGuard = %(\u200b)
-  GuardedInnerIndent = %(\n\u200b )
+  GuardedIndent = %(\u00a0)
+  GuardedInnerIndent = %(\n\u00a0)
 
   def setup options
     super
@@ -88,7 +88,7 @@ class CodeRayEncoder < ::CodeRay::Encoders::Encoder
       @start_of_line = true
     else
       # NOTE add guard character to prevent Prawn from trimming indentation
-      text.prepend IndentGuard if @start_of_line && (text.start_with? ' ')
+      text[0] = GuardedIndent if @start_of_line && (text.start_with? ' ')
       text.gsub! InnerIndent, GuardedInnerIndent if text.include? InnerIndent
 
       # NOTE this optimization assumes we don't support/use background colors

--- a/lib/asciidoctor-pdf/rouge_ext.rb
+++ b/lib/asciidoctor-pdf/rouge_ext.rb
@@ -1,0 +1,4 @@
+require 'rouge'
+require_relative 'rouge_ext/formatters/prawn'
+require_relative 'rouge_ext/css_theme'
+require_relative 'rouge_ext/themes/pastie'

--- a/lib/asciidoctor-pdf/rouge_ext/css_theme.rb
+++ b/lib/asciidoctor-pdf/rouge_ext/css_theme.rb
@@ -1,0 +1,14 @@
+module Rouge
+class CSSTheme
+  # Patch style_for to return most specific style first
+  # See https://github.com/jneen/rouge/issues/280 (fix pending)
+  def style_for token
+    token.token_chain.reverse_each do |t|
+      if (s = styles[t])
+        return s
+      end
+    end
+    nil
+  end
+end
+end

--- a/lib/asciidoctor-pdf/rouge_ext/formatters/prawn.rb
+++ b/lib/asciidoctor-pdf/rouge_ext/formatters/prawn.rb
@@ -1,0 +1,121 @@
+module Rouge
+module Formatters
+# Transforms a token stream into an array of 
+# formatted text fragments for use with Prawn.
+class Prawn < Formatter
+  tag 'prawn'
+
+  EOL = %(\n)
+  NoBreakSpace = %(\u00a0)
+  InnerIndent = %(\n )
+  GuardedIndent = %(\u00a0)
+  GuardedInnerIndent = %(\n\u00a0)
+  BoldStyle = [:bold].to_set
+  ItalicStyle = [:italic].to_set
+  BoldItalicStyle = [:bold, :italic].to_set
+
+  def initialize opts = {}
+    unless ::Rouge::Theme === (theme = opts[:theme])
+      unless theme && (theme = ::Rouge::Theme.find theme)
+        theme = ::Rouge::Themes::Pastie
+      end
+      theme = theme.new
+    end
+    @theme = theme
+    @normalized_colors = {}
+    @linenum_fragment_base = (create_fragment Token['Generic.Lineno']).merge linenum: true
+  end
+
+  # Override format method so fragments don't get flatted to a string
+  # and to add an options Hash.
+  def format tokens, opts = {}
+    stream tokens, opts
+  end
+
+  def stream tokens, opts = {}
+    if opts[:line_numbers]
+      # TODO implement line number start (offset)
+      linenum = 0
+      fragments = []
+      fragments << (create_linenum_fragment linenum += 1)
+      tokens.each do |tok, val|
+        if val == EOL
+          fragments << { text: EOL }
+          fragments << (create_linenum_fragment linenum += 1)
+        elsif val.include? EOL
+          base_fragment = create_fragment tok, val
+          val.each_line do |line|
+            fragments << (base_fragment.merge text: line)
+            # NOTE append linenum fragment if there's a next line; only works if source doesn't have trailing endline
+            if line.end_with? EOL
+              fragments << (create_linenum_fragment linenum += 1)
+            end
+          end
+        else
+          fragments << (create_fragment tok, val)
+        end
+      end
+      # NOTE drop orphaned linenum fragment (due to trailing endline in source)
+      fragments.pop if (last_fragment = fragments[-1]) && last_fragment[:linenum]
+      # NOTE pad numbers that have less digits than the largest line number
+      if (linenum_w = (linenum / 10) + 1) > 1
+        # NOTE extra column is the trailing space after the line number
+        linenum_w += 1
+        fragments.each do |fragment|
+          fragment[:text] = %(#{fragment[:text].rjust linenum_w, NoBreakSpace}) if fragment[:linenum]
+        end
+      end
+      fragments
+    else
+      start_of_line = true
+      tokens.map do |tok, val|
+        # match one or more consecutive endlines
+        if val == EOL || (val == (EOL * val.length))
+          start_of_line = true
+          { text: val }
+        else
+          val[0] = GuardedIndent if start_of_line && (val.start_with? ' ')
+          val.gsub! InnerIndent, GuardedInnerIndent if val.include? InnerIndent
+          start_of_line = val.end_with? EOL
+          # NOTE this optimization assumes we don't support/use background colors
+          val.rstrip.empty? ? { text: val } : (create_fragment tok, val)
+        end
+      end
+      # QUESTION should we strip trailing newline?
+    end
+  end
+
+  # TODO method could still be optimized (for instance, check if val is EOL or empty)
+  def create_fragment tok, val = nil
+    fragment = val ? { text: val } : {}
+    if (style_rules = @theme.style_for tok)
+      # TODO support background color
+      if (fg = normalize_color style_rules.fg)
+        fragment[:color] = fg
+      end
+      if style_rules[:bold]
+        fragment[:styles] = style_rules[:italic] ? BoldItalicStyle : BoldStyle
+      elsif style_rules[:italic]
+        fragment[:styles] = ItalicStyle
+      end
+    end
+    fragment
+  end
+
+  def create_linenum_fragment linenum
+    @linenum_fragment_base.merge text: %(#{linenum} )
+  end
+
+  def normalize_color raw
+    return unless raw
+    if (normalized = @normalized_colors[raw])
+      normalized
+    else
+      normalized = (raw.start_with? '#') ? raw[1..-1] : raw
+      normalized = normalized.each_char.map {|c| c * 2 }.join if normalized.size == 3
+      @normalized_colors[raw] = normalized
+    end
+  end
+end
+end
+end

--- a/lib/asciidoctor-pdf/rouge_ext/themes/pastie.rb
+++ b/lib/asciidoctor-pdf/rouge_ext/themes/pastie.rb
@@ -1,0 +1,61 @@
+module Rouge
+module Themes
+# A Rouge theme that matches the pastie style from Pygments.
+# See https://bitbucket.org/birkenfeld/pygments-main/src/default/pygments/styles/pastie.py
+class Pastie < CSSTheme
+  name 'pastie' 
+
+  style Text::Whitespace,          fg: '#bbbbbb'
+
+  style Comment,                   fg: '#888888'
+  style Comment::Preproc,          fg: '#cc0000', bold: true
+  style Comment::Special,          fg: '#cc0000', bg: '#fff0f0', bold: true
+
+  style Error,                     fg: '#a61717', bg: '#e3d2d2'
+  style Generic::Error,            fg: '#aa0000'
+  style Generic::Traceback,        fg: '#aa0000'
+
+  style Generic::Deleted,          fg: '#000000', bg: '#ffdddd'
+  style Generic::Emph,             italic: true
+  style Generic::Inserted,         fg: '#000000', bg: '#ddffdd'
+  style Generic::Heading,          fg: '#333333'
+  #style Generic::Lineno,           fg: '#555555'
+  style Generic::Lineno,           fg: '#888888'
+  style Generic::Output,           fg: '#888888'
+  style Generic::Prompt,           fg: '#555555'
+  style Generic::Strong,           bold: true
+  style Generic::Subheading,       fg: '#666666'
+
+  style Keyword,                   fg: '#008800', bold: true
+  style Keyword::Pseudo,           fg: '#008800'
+  style Keyword::Type,             fg: '#888888', bold: true
+
+  style Literal::Number,           fg: '#0000dd', bold: true
+
+  style Literal::String,           fg: '#dd2200', bg: '#fff0f0'
+  style Literal::String::Escape,   fg: '#0044dd'
+  style Literal::String::Interpol, fg: '#3333bb'
+  style Literal::String::Other,    fg: '#22bb22', bg: '#f0fff0'
+  style Literal::String::Regex,    fg: '#008800', bg: '#fff0ff'
+  style Literal::String::Symbol,   fg: '#aa6600'
+
+  style Name::Attribute,           fg: '#336699'
+  style Name::Builtin,             fg: '#003388'
+  style Name::Class,               fg: '#bb0066', bold: true
+  style Name::Constant,            fg: '#003366', bold: true
+  style Name::Decorator,           fg: '#555555'
+  style Name::Exception,           fg: '#bb0066', bold: true
+  style Name::Function,            fg: '#0066bb', bold: true
+  #style Name::Label,               fg: '#336699', italic: true
+  style Name::Label,               fg: '#336699'
+  style Name::Namespace,           fg: '#bb0066', bold: true
+  style Name::Property,            fg: '#336699', bold: true
+  style Name::Tag,                 fg: '#bb0066', bold: true
+  style Name::Variable::Global,    fg: '#dd7700'
+  style Name::Variable::Instance,  fg: '#3333bb'
+  style Name::Variable,            fg: '#336699'
+
+  style Operator::Word,            fg: '#008800'
+end
+end
+end


### PR DESCRIPTION
- add integration with Rouge for highlighting source listings
- guard indentation within Rouge formatter
- organize the code to setup source highlighting
- enable line number support when highlighting with Rouge
- add pastie theme for Rouge
- patch Rouge style lookup (see https://github.com/jneen/rouge/issues/280)