### PR TITLE
resolves #264 modify vertical alignment setting for running header/footer

### DIFF
--- a/data/themes/default-theme.yml
+++ b/data/themes/default-theme.yml
@@ -215,8 +215,8 @@ footer:
   border_width: 0.25
   height: $base_line_height_length * 2.5
   padding: [$base_line_height_length / 2, 1, 0, 1]
-  valign: top
-  #image_valign: <alignment> or <number>
+  vertical_align: top
+  #image_vertical_align: <alignment> or <number>
   # additional attributes for content:
   # * {page-count}
   # * {page-number}

--- a/docs/theming-guide.adoc
+++ b/docs/theming-guide.adoc
@@ -1422,13 +1422,13 @@ Block styles are applied to the following block types:
 |<<measurement-units,measurement>>, <<measurement-units,measurement array [4]>>
 |padding: [0, 3, 0, 3]
 
-|header_image_valign
-|top, center, bottom, <<measurement-units,measurement>>
-|image_valign: 4
+|header_image_vertical_align
+|top, middle, bottom, <<measurement-units,measurement>>
+|image_vertical_align: 4
 
-|header_valign
-|top, center, bottom
-|valign: center
+|header_vertical_align
+|top, middle, bottom
+|vertical_align: center
 
 |header_<side>_content_<align>^[1]^
 |quoted string
@@ -1475,13 +1475,13 @@ Block styles are applied to the following block types:
 |<<measurement-units,measurement>>, <<measurement-units,measurement array [4]>>
 |padding: [0, 3, 0, 3]
 
-|footer_image_valign
-|top, center, bottom, <<measurement-units,measurement>>
-|image_valign: 4
+|footer_image_vertical_align
+|top, middle, bottom, <<measurement-units,measurement>>
+|image_vertical_align: 4
 
-|footer_valign
-|top, center, bottom
-|valign: top
+|footer_vertical_align
+|top, middle, bottom
+|vertical_align: top
 
 |footer_<side>_content_<align>^[1]^
 |quoted string
@@ -1536,13 +1536,13 @@ Here's an example of how to use an image in the running header (which also appli
 ----
 header:
   height: 0.75in
-  image_valign: 2 # <1>
+  image_vertical_align: 2 # <1>
   recto_content:
     center: image:footer-logo.png[width=80]
   verso_content:
     center: $header_recto_content_center
 ----
-<1> You can use the `footer_valign` attribute to slighly nudge the image up or down.
+<1> You can use the `footer_vertical_align` attribute to slighly nudge the image up or down.
 
 CAUTION: The image must fit in the allotted space for the running header or footer.
 Otherwise, you will run into layout issues.

--- a/lib/asciidoctor-pdf/converter.rb
+++ b/lib/asciidoctor-pdf/converter.rb
@@ -1848,8 +1848,8 @@ class Converter < ::Prawn::Document
       trim_border_width = @theme.header_border_width || @theme.base_border_width
       trim_border_style = (@theme.header_border_style || :solid).to_sym
       trim_border_color = resolve_theme_color :header_border_color
-      trim_valign = (@theme.header_valign || :center).to_sym
-      trim_img_valign = @theme.header_image_valign || trim_valign
+      trim_valign = (@theme.header_vertical_align || :middle).to_sym
+      trim_img_valign = @theme.header_image_vertical_align
     else
       # NOTE height is required atm
       trim_top = trim_height = @theme.footer_height || page_margin_bottom
@@ -1862,15 +1862,21 @@ class Converter < ::Prawn::Document
       trim_border_width = @theme.footer_border_width || @theme.base_border_width
       trim_border_style = (@theme.footer_border_style || :solid).to_sym
       trim_border_color = resolve_theme_color :footer_border_color
-      trim_valign = (@theme.footer_valign || :center).to_sym
-      trim_img_valign = @theme.footer_image_valign || trim_valign
+      trim_valign = (@theme.footer_vertical_align || :middle).to_sym
+      trim_img_valign = @theme.footer_image_vertical_align
     end
 
     trim_stamp = %(#{position})
     trim_content_left = trim_left + trim_padding[3]
     trim_content_width = trim_width - trim_padding[3] - trim_padding[1]
     trim_border_color = nil if trim_border_width == 0
-    if ['top', 'center', 'bottom'].include? trim_img_valign
+    trim_valign == :center if trim_valign == :middle
+    case trim_img_valign
+    when nil
+      trim_img_valign = trim_valign
+    when 'middle'
+      trim_img_valign = :center
+    when 'top', 'center', 'bottom'
       trim_img_valign = trim_img_valign.to_sym
     end
 


### PR DESCRIPTION
- permit the value of "middle" as an alias for "center"
- rename attribute from valign to vertical_align to be consistent w/ CSS
- update theming guide accordingly