### PR TITLE
resolves #274 make line height in running header/footer configurable

### DIFF
--- a/data/themes/default-theme.yml
+++ b/data/themes/default-theme.yml
@@ -214,6 +214,7 @@ footer:
   border_color: dddddd
   border_width: 0.25
   height: $base_line_height_length * 2.5
+  line_height: 1
   padding: [$base_line_height_length / 2, 1, 0, 1]
   vertical_align: top
   #image_vertical_align: <alignment> or <number>

--- a/docs/theming-guide.adoc
+++ b/docs/theming-guide.adoc
@@ -1418,6 +1418,11 @@ Block styles are applied to the following block types:
 |<<measurement-units,measurement>>
 |height: 0.75in
 
+|header_line_height
+|<<values,number>> +
+(default: $base_line_height)
+|height: 1.2
+
 |header_padding
 |<<measurement-units,measurement>>, <<measurement-units,measurement array [4]>>
 |padding: [0, 3, 0, 3]
@@ -1471,6 +1476,11 @@ Block styles are applied to the following block types:
 |<<measurement-units,measurement>>
 |height: 0.75in
 
+|footer_line_height
+|<<values,number>> +
+(default: $base_line_height)
+|height: 1.2
+
 |footer_padding
 |<<measurement-units,measurement>>, <<measurement-units,measurement array [4]>>
 |padding: [0, 3, 0, 3]
@@ -1514,6 +1524,7 @@ Here's an example that shows how these attributes can be used in the running foo
 ----
 footer:
   height: 0.75in
+  line_height: 1
   recto_content:
     right: '{section-or-chapter-title} | *{page-number}*'
   verso_content:
@@ -1528,6 +1539,7 @@ To force a hard line break in the output, add [x-]+{space}{plus}+ to the end of 
 ----
 footer:
   height: 0.75in
+  line_height: 1.2
   recto_content:
     right: |
       Section Title - Page Number +


### PR DESCRIPTION
- allow header_line_height & footer_line_height to be specified in theme
- properly calculate the height and placement of running content
- placement of image in running content should respect padding settings
- document header_line_height & footer_line_height in theme guide
- update default theme to use new settings