### PR TITLE
resolves #222 parse inline image macro value of page_background_image

### DIFF
--- a/docs/theming-guide.adoc
+++ b/docs/theming-guide.adoc
@@ -679,8 +679,8 @@ TBW
 |background_color: #ffffff
 
 |page_background_image
-|path (relative to pdf-stylesdir)
-|background_image: watermark.jpg
+|path (absolute or relative to pdf-stylesdir)
+|background_image: \image:watermark.png[]
 
 |page_layout
 |portrait, landscape +
@@ -883,13 +883,21 @@ The literal key is used for inline monospaced text in prose and table cells.
 |left, center, right, justify
 |align: right
 
+|title_page_background_color
+|<<colors,color>>
+|background_color: #eaeaea
+
+|title_page_background_image
+|path (absolute or relative to pdf-stylesdir)
+|background_image: \image:title.png[]
+
 |title_page_logo_align
 |left, center, right
 |logo_align: right
 
 |title_page_logo_image
 |inline image macro
-|+logo_image: image:logo.png[scaledwidth=25%]+
+|logo_image: \image:logo.png[scaledwidth=25%]
 
 |title_page_logo_top
 |percentage


### PR DESCRIPTION
- support use of inline image macro in value of page_background_image theme key
- allow page background to be set by document (using page-background-image attribute)
- rename title-background-image attribute to title-page-background-image
- refactor background image resolution into a method
- document background image keys in theming guide