### PR TITLE
resolves #289 remove use of "rhythm" theme keys from converter

### DIFF
--- a/data/themes/base-theme.yml
+++ b/data/themes/base-theme.yml
@@ -1,7 +1,6 @@
 # NOTE file is read "as is"; variables are not parsed; key layout must be flat
-# FIXME internal use of vertical_rhythm & horizontal_rhythm needs to be deprecated
-vertical_rhythm: 12
-horizontal_rhythm: 12
+# QUESTION should vertical_spacing be block_spacing instead?
+vertical_spacing: 12
 page_background_color: 'FFFFFF'
 page_layout: portrait
 # 36 is equivalent to 0.5in
@@ -43,8 +42,7 @@ outline_list_indent: 30
 outline_list_item_spacing: 6
 description_list_description_indent: 30
 description_list_term_font_style: normal
-# NOTE currently block_padding _is_ the sidebar padding
-block_padding: 12
+description_list_term_spacing: 4
 block_margin_top: 0
 block_margin_bottom: 12
 caption_align: left
@@ -56,8 +54,10 @@ abstract_line_height: 1.4
 abstract_padding: 0
 admonition_border_color: 'EEEEEE'
 admonition_border_width: 0.5
+admonition_padding: [0, 12, 0, 12]
 blockquote_border_color: 'EEEEEE'
 blockquote_border_width: 4
+blockquote_padding: [6, 12, -6, 14]
 code_font_family: Courier
 code_font_size: 10.5
 code_line_height: 1.2
@@ -67,13 +67,16 @@ code_border_width: 0.5
 conum_line_height: 1.15
 example_border_color: 'EEEEEE'
 example_border_width: 0.5
+# FIXME reenable margin bottom once margin collapsing is implemented
+example_padding: [12, 12, 0, 12]
 image_align: left
 lead_font_size: 13.5
 lead_line_height: 1.4
 prose_margin_top: 0
 prose_margin_bottom: 12
 sidebar_background_color: 'EEEEEE'
-sidebar_title:
+# FIXME reenable margin bottom once margin collapsing is implemented
+sidebar_padding: [12, 12, 0, 12]
 sidebar_title_align: center
 sidebar_title_font_style: bold
 table_border_color: '000000'

--- a/data/themes/default-theme.yml
+++ b/data/themes/default-theme.yml
@@ -62,6 +62,8 @@ base:
 # correct line height for Noto Serif metrics (comes with built-in line height)
 vertical_rhythm: $base_line_height_length
 horizontal_rhythm: $base_line_height_length
+# QUESTION should vertical_spacing be block_spacing instead?
+vertical_spacing: $vertical_rhythm
 link:
   font_color: 428bca
 # literal is currently used for inline monospaced in prose and table cells
@@ -108,8 +110,6 @@ title_page:
 block:
   margin_top: 0
   margin_bottom: $vertical_rhythm
-  # NOTE currently block_padding _is_ the sidebar padding
-  padding: [$vertical_rhythm, $vertical_rhythm * 1.25, $vertical_rhythm, $vertical_rhythm * 1.25]
 caption:
   align: left
   font_style: italic
@@ -128,11 +128,13 @@ abstract:
 admonition:
   border_color: $base_border_color
   border_width: $base_border_width
+  padding: [0, $horizontal_rhythm, 0, $horizontal_rhythm]
 blockquote:
   font_color: $base_font_color
   font_size: $base_font_size_large
   border_color: $base_border_color
   border_width: 5
+  padding: [$vertical_rhythm / 2, $horizontal_rhythm, $vertical_rhythm / -2, $horizontal_rhythm + $blockquote_border_width / 2]
   cite_font_size: $base_font_size_small
   cite_font_color: 999999
 # code is used for source blocks (perhaps change to source or listing?)
@@ -156,6 +158,8 @@ example:
   border_radius: $base_border_radius
   border_width: 0.75
   background_color: transparent
+  # FIXME reenable margin bottom once margin collapsing is implemented
+  padding: [$vertical_rhythm, $horizontal_rhythm, 0, $horizontal_rhythm]
 image:
   align: left
 prose:
@@ -166,6 +170,8 @@ sidebar:
   border_radius: $base_border_radius
   border_width: $base_border_width
   background_color: eeeeee
+  # FIXME reenable margin bottom once margin collapsing is implemented
+  padding: [$vertical_rhythm, $vertical_rhythm * 1.25, 0, $vertical_rhythm * 1.25]
   title:
     align: center
     font_color: $heading_font_color
@@ -180,6 +186,7 @@ thematic_break:
   margin_bottom: $vertical_rhythm * 1.5
 description_list:
   term_font_style: italic
+  term_spacing: $vertical_rhythm / 4
   description_indent: $horizontal_rhythm * 1.25
 outline_list:
   indent: $horizontal_rhythm * 1.5


### PR DESCRIPTION
- remove use of horizontal_rhythm and vertical_rhythm from converter
- introduce block-specific padding keys
- introduce vertical_spacing key
  * used as a fallback for a block's margin_bottom when key is missing