### PR TITLE
resolves #121. Admonition icon customization by theme.

### DIFF
--- a/lib/asciidoctor-pdf/converter.rb
+++ b/lib/asciidoctor-pdf/converter.rb
@@ -1782,10 +1782,14 @@ class Converter < ::Prawn::Document
   end
 
   def admonition_icon_data key
-    @theme.admonition_icons[key].tap do |data|
-      AdmonitionIcons[key].each do |k, v|
-        data[k] ||= v
+    if @theme.admonition_icons && @theme.admonition_icons[key]
+      @theme.admonition_icons[key].tap do |data|
+        AdmonitionIcons[key].each do |k, v|
+          data[k] ||= v
+        end
       end
+    else
+      AdmonitionIcons[key]
     end
   end
 

--- a/lib/asciidoctor-pdf/converter.rb
+++ b/lib/asciidoctor-pdf/converter.rb
@@ -33,11 +33,11 @@ class Converter < ::Prawn::Document
 
   AsciidoctorVersion = ::Gem::Version.create ::Asciidoctor::VERSION
   AdmonitionIcons = {
-    caution:   { key: 'fa-fire', color: 'BF3400' },
-    important: { key: 'fa-exclamation-circle', color: 'BF0000' },
-    note:      { key: 'fa-info-circle', color: '19407C' },
-    tip:       { key: 'fa-lightbulb-o', color: '111111' },
-    warning:   { key: 'fa-exclamation-triangle', color: 'BF6900' }
+    caution:   { key: 'fa-fire', color: 'BF3400', size: 24 },
+    important: { key: 'fa-exclamation-circle', color: 'BF0000', size: 24 },
+    note:      { key: 'fa-info-circle', color: '19407C', size: 24 },
+    tip:       { key: 'fa-lightbulb-o', color: '111111', size: 24 },
+    warning:   { key: 'fa-exclamation-triangle', color: 'BF6900', size: 24 }
   }
   Alignments = [:left, :center, :right]
   AlignmentNames = ['left', 'center', 'right']
@@ -435,8 +435,14 @@ class Converter < ::Prawn::Document
                 # FIXME HACK make title in this location look right
                 label_margin_top = node.title? ? @theme.caption_margin_inside : 0
                 if icons
-                  admon_icon_data = AdmonitionIcons[label]
-                  icon admon_icon_data[:key], valign: :center, align: :center, color: admon_icon_data[:color], size: (admonition_icon_size node)
+                  admon_icon_data = admonition_icon_data label
+                  opts = {
+                    valign: :center,
+                    align: :center,
+                    color: admon_icon_data[:color],
+                    size: (admonition_icon_size node, admon_icon_data[:size])
+                  }
+                  icon admon_icon_data[:key], opts
                 else
                   layout_prose label, valign: :center, style: :bold, line_height: 1, margin_top: label_margin_top, margin_bottom: 0
                 end
@@ -1089,7 +1095,7 @@ class Converter < ::Prawn::Document
   end
 
   # Adds guards to preserve indentation
-  def guard_indentation fragments 
+  def guard_indentation fragments
     start_of_line = true
     fragments.each do |fragment|
       next if (text = fragment[:text]).empty?
@@ -1773,6 +1779,14 @@ class Converter < ::Prawn::Document
   def admonition_icon_size node, max_size = 24
     min_height = bounds.height.floor
     min_height < max_size ? min_height : max_size
+  end
+
+  def admonition_icon_data key
+    @theme.admonition_icons[key].tap do |data|
+      AdmonitionIcons[key].each do |k, v|
+        data[k] ||= v
+      end
+    end
   end
 
   # TODO delegate to layout_page_header and layout_page_footer per page

--- a/lib/asciidoctor-pdf/theme_loader.rb
+++ b/lib/asciidoctor-pdf/theme_loader.rb
@@ -86,7 +86,9 @@ class ThemeLoader
   private
 
   def process_entry key, val, data
-    if key != 'font_catalog' && ::Hash === val
+    if key == "admonition_icons"
+      data[key] = symbolize_keys val
+    elsif key != 'font_catalog' && ::Hash === val
       val.each do |key2, val2|
         process_entry %(#{key}_#{key2.tr '-', '_'}), val2, data
       end
@@ -106,7 +108,7 @@ class ThemeLoader
       expr
     end
   end
-  
+
   # NOTE we assume expr is a String
   def expand_vars expr, vars
     if (idx = (expr.index '$'))
@@ -119,7 +121,7 @@ class ThemeLoader
       expr
     end
   end
-  
+
   def evaluate_math expr
     return expr if !(::String === expr) || ColorValue === expr
     original = expr
@@ -222,6 +224,18 @@ class ThemeLoader
       value[0..5].rjust 6, '0'
     end
     HexColorValue.new value.upcase
+  end
+
+  def symbolize_keys hash
+    hash.inject({}) do |data, (k, v)|
+      data.tap do |i|
+        if v.is_a? Hash
+          i[k.to_sym] = symbolize_keys v
+        else
+          i[k.to_sym] = v
+        end
+      end
+    end
   end
 end
 end


### PR DESCRIPTION
This patch allows for admonition icon customization via the pdf theme.

Here's an example of the theme syntax:

```yaml
admonition:
  icon:
    tip:
      key: fa-arrows
      color: 0099FF
      size: 14
```

Supported icon keys currently are: `key`, `color` and `size`. If any of these are not specified, they will remain as the Asciidoctor defaults.

I haven't tested the patch to ensure that I haven't broken something, so it's probably best to double-check that everything works okay!