### PR TITLE
update prawn-icon to 1.0.0

### DIFF
--- a/asciidoctor-pdf.gemspec
+++ b/asciidoctor-pdf.gemspec
@@ -42,7 +42,7 @@ An extension for Asciidoctor that converts AsciiDoc documents to PDF using the P
   s.add_runtime_dependency 'prawn-table', '0.2.2'
   s.add_runtime_dependency 'prawn-templates', '0.0.3'
   s.add_runtime_dependency 'prawn-svg', '0.21.0'
-  s.add_runtime_dependency 'prawn-icon', '0.6.4'
+  s.add_runtime_dependency 'prawn-icon', '1.0.0'
   s.add_runtime_dependency 'safe_yaml', '1.0.4'
   s.add_runtime_dependency 'thread_safe', '0.3.5'
   # For our usage, treetop 1.6.2 is slower than 1.5.3


### PR DESCRIPTION
Update `Prawn/Icon` from `v0.6.4` to `1.0.0`. 

The only (potentially) breaking changes involve the use of a small number of icons removed from the `octicon` font. See the  [changelog](https://github.com/jessedoyle/prawn-icon/blob/master/CHANGELOG.md).