### PR TITLE
Add icon rendering documentation with icon sets

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -131,6 +131,10 @@ Choose one (or more) of the following:
 
 .Pygments
  $ gem install pygments.rb
+ 
+IMPORTANT: You'll need to the `coderay` gem installed to run this example since it uses the `source-highlighter` attribute with the value of `coderay`. You can invoke syntax highlighting with coderay by adding the following line at the tom of the document.
+
+:source-highlighter: coderay 
 
 Assuming all the required gems install properly, verify you can run the `asciidoctor-pdf` script:
 
@@ -159,8 +163,6 @@ It's time to convert the AsciiDoc document directly to PDF.
 
 === Convert AsciiDoc to PDF
 
-IMPORTANT: You'll need to the `coderay` gem installed to run this example since it uses the `source-highlighter` attribute with the value of `coderay`.
-
 Converting to PDF is a simple as running the `asciidoctor-pdf` script using Ruby and passing our AsciiDoc document as the first argument.
 
  $ asciidoctor-pdf basic-example.adoc
@@ -184,6 +186,34 @@ The pain of the DocBook toolchain should be melting away about now.
 The layout and styling of the PDF is driven by a YAML configuration file.
 To learn how the theming system works and how to create and apply custom themes, refer to the <<docs/theming-guide.adoc#,Asciidoctor PDF Theme Guide>>.
 You can use the built-in theme files, which you can find in the [file]_data/themes_ directory, as examples.
+
+== Icons
+
+You can use icons in your PDF document by using one of 4 icon sets.
+
+fa - Font Awesome
+octicon - Octicons
+fi - Foundation icons
+pf - Payment font
+
+You can set the following attributes globally at the top of your document
+
+:icons: font
+:icon-set: octicon
+
+An example for "the amazon icon in the pf (payment font) icon set" is written as:
+
+Available now at icon:amazon[set=pf]
+
+In addition to the sizes supported in the HTML backend (lg, 1x, 2x, etc), you can enter any relative value in the size attribute (e.g., 1.5em, 150%, etc).
+
+icon:android[size=40em]
+
+Coloring of the icon is unsupported yet.
+
+You can enable use of fonts during PDF generation with the following command. In this example, we enable font awesome icons
+
+ $ asciidoctor-pdf -a icons=font basic-example.adoc
 
 == Optional scripts
 


### PR DESCRIPTION
Most of the icon enabling instructions is copied from issue #97. Also moved the important tip about sourcecode highlighting within the coderay section