### PR TITLE
Add support for quoted text attributes (prefixed in square brackets)

### DIFF
--- a/lib/asciidoctor-pdf/converter.rb
+++ b/lib/asciidoctor-pdf/converter.rb
@@ -270,7 +270,7 @@ class Converter < ::Prawn::Document
 
     pdf_opts[:page_size] = (page_size || 'A4')
 
-    pdf_opts[:text_formatter] ||= FormattedText::Formatter.new theme: theme
+    pdf_opts[:text_formatter] ||= FormattedText::Formatter.new theme: theme, doc: self
     pdf_opts
   end
 

--- a/lib/asciidoctor-pdf/converter.rb
+++ b/lib/asciidoctor-pdf/converter.rb
@@ -1452,9 +1452,11 @@ class Converter < ::Prawn::Document
 
   def convert_inline_kbd node
     if (keys = node.attr 'keys').size == 1
-      %(<code>#{keys[0]}</code>)
+      #%(<code>#{keys[0]}</code>)
+      %(<kbd>#{keys[0]}</kbd>)
     else
-      keys.map {|key| %(<code>#{key}</code>+) }.join.chop
+      #keys.map {|key| %(<code>#{key}</code>+) }.join.chop
+      keys.map {|key| %(<kbd>#{key}</kbd>+) }.join.chop
     end
   end
 

--- a/lib/asciidoctor-pdf/formatted_text/formatter.rb
+++ b/lib/asciidoctor-pdf/formatted_text/formatter.rb
@@ -7,7 +7,7 @@ class Formatter
 
   def initialize options = {}
     @parser = MarkupParser.new
-    @transform = Transform.new merge_adjacent_text_nodes: true, theme: options[:theme]
+    @transform = Transform.new merge_adjacent_text_nodes: true, theme: options[:theme], doc: options[:doc]
   end
 
   def format string, *args

--- a/lib/asciidoctor-pdf/formatted_text/parser.rb
+++ b/lib/asciidoctor-pdf/formatted_text/parser.rb
@@ -191,7 +191,7 @@ module Markup
       r1 = true
       @index += match_len
     else
-      terminal_parse_failure('<')
+      terminal_parse_failure('\'<\'')
       r1 = nil
     end
     s0 << r1
@@ -215,7 +215,7 @@ module Markup
               r8 = true
               @index += match_len
             else
-              terminal_parse_failure('/')
+              terminal_parse_failure('\'/\'')
               r8 = nil
             end
             s5 << r8
@@ -238,7 +238,7 @@ module Markup
               r9 = true
               @index += match_len
             else
-              terminal_parse_failure('>')
+              terminal_parse_failure('\'>\'')
               r9 = nil
             end
             s0 << r9
@@ -297,7 +297,7 @@ module Markup
       r1 = true
       @index += match_len
     else
-      terminal_parse_failure('<')
+      terminal_parse_failure('\'<\'')
       r1 = nil
     end
     s0 << r1
@@ -312,7 +312,7 @@ module Markup
             r4 = true
             @index += match_len
           else
-            terminal_parse_failure('>')
+            terminal_parse_failure('\'>\'')
             r4 = nil
           end
           s0 << r4
@@ -349,7 +349,7 @@ module Markup
       r1 = true
       @index += match_len
     else
-      terminal_parse_failure('a')
+      terminal_parse_failure('\'a\'')
       r1 = nil
     end
     if r1
@@ -360,7 +360,7 @@ module Markup
         r2 = instantiate_node(SyntaxNode,input, index...(index + match_len))
         @index += match_len
       else
-        terminal_parse_failure('code')
+        terminal_parse_failure('\'code\'')
         r2 = nil
       end
       if r2
@@ -371,7 +371,7 @@ module Markup
           r3 = instantiate_node(SyntaxNode,input, index...(index + match_len))
           @index += match_len
         else
-          terminal_parse_failure('color')
+          terminal_parse_failure('\'color\'')
           r3 = nil
         end
         if r3
@@ -382,7 +382,7 @@ module Markup
             r4 = instantiate_node(SyntaxNode,input, index...(index + match_len))
             @index += match_len
           else
-            terminal_parse_failure('del')
+            terminal_parse_failure('\'del\'')
             r4 = nil
           end
           if r4
@@ -393,7 +393,7 @@ module Markup
               r5 = instantiate_node(SyntaxNode,input, index...(index + match_len))
               @index += match_len
             else
-              terminal_parse_failure('em')
+              terminal_parse_failure('\'em\'')
               r5 = nil
             end
             if r5
@@ -404,7 +404,7 @@ module Markup
                 r6 = instantiate_node(SyntaxNode,input, index...(index + match_len))
                 @index += match_len
               else
-                terminal_parse_failure('font')
+                terminal_parse_failure('\'font\'')
                 r6 = nil
               end
               if r6
@@ -415,7 +415,7 @@ module Markup
                   r7 = instantiate_node(SyntaxNode,input, index...(index + match_len))
                   @index += match_len
                 else
-                  terminal_parse_failure('span')
+                  terminal_parse_failure('\'span\'')
                   r7 = nil
                 end
                 if r7
@@ -426,7 +426,7 @@ module Markup
                     r8 = instantiate_node(SyntaxNode,input, index...(index + match_len))
                     @index += match_len
                   else
-                    terminal_parse_failure('strong')
+                    terminal_parse_failure('\'strong\'')
                     r8 = nil
                   end
                   if r8
@@ -437,7 +437,7 @@ module Markup
                       r9 = instantiate_node(SyntaxNode,input, index...(index + match_len))
                       @index += match_len
                     else
-                      terminal_parse_failure('sub')
+                      terminal_parse_failure('\'sub\'')
                       r9 = nil
                     end
                     if r9
@@ -448,15 +448,27 @@ module Markup
                         r10 = instantiate_node(SyntaxNode,input, index...(index + match_len))
                         @index += match_len
                       else
-                        terminal_parse_failure('sup')
+                        terminal_parse_failure('\'sup\'')
                         r10 = nil
                       end
                       if r10
                         r10 = SyntaxNode.new(input, (index-1)...index) if r10 == true
                         r0 = r10
                       else
-                        @index = i0
-                        r0 = nil
+                        if (match_len = has_terminal?('kbd', false, index))
+                          r11 = instantiate_node(SyntaxNode,input, index...(index + match_len))
+                          @index += match_len
+                        else
+                          terminal_parse_failure('\'kbd\'')
+                          r11 = nil
+                        end
+                        if r11
+                          r11 = SyntaxNode.new(input, (index-1)...index) if r11 == true
+                          r0 = r11
+                        else
+                          @index = i0
+                          r0 = nil
+                        end
                       end
                     end
                   end
@@ -489,7 +501,7 @@ module Markup
       r1 = instantiate_node(SyntaxNode,input, index...(index + match_len))
       @index += match_len
     else
-      terminal_parse_failure('br')
+      terminal_parse_failure('\'br\'')
       r1 = nil
     end
     if r1
@@ -500,7 +512,7 @@ module Markup
         r2 = instantiate_node(SyntaxNode,input, index...(index + match_len))
         @index += match_len
       else
-        terminal_parse_failure('img')
+        terminal_parse_failure('\'img\'')
         r2 = nil
       end
       if r2
@@ -611,7 +623,7 @@ module Markup
           r4 = true
           @index += match_len
         else
-          terminal_parse_failure('=')
+          terminal_parse_failure('\'=\'')
           r4 = nil
         end
         s0 << r4
@@ -620,7 +632,7 @@ module Markup
             r5 = true
             @index += match_len
           else
-            terminal_parse_failure('"')
+            terminal_parse_failure('\'"\'')
             r5 = nil
           end
           s0 << r5
@@ -647,7 +659,7 @@ module Markup
                 r8 = true
                 @index += match_len
               else
-                terminal_parse_failure('"')
+                terminal_parse_failure('\'"\'')
                 r8 = nil
               end
               s0 << r8
@@ -699,7 +711,7 @@ module Markup
       r1 = instantiate_node(SyntaxNode,input, index...(index + match_len))
       @index += match_len
     else
-      terminal_parse_failure('</')
+      terminal_parse_failure('\'</\'')
       r1 = nil
     end
     s0 << r1
@@ -711,7 +723,7 @@ module Markup
           r3 = true
           @index += match_len
         else
-          terminal_parse_failure('>')
+          terminal_parse_failure('\'>\'')
           r3 = nil
         end
         s0 << r3
@@ -811,7 +823,7 @@ module Markup
       r1 = true
       @index += match_len
     else
-      terminal_parse_failure('&')
+      terminal_parse_failure('\'&\'')
       r1 = nil
     end
     s0 << r1
@@ -822,7 +834,7 @@ module Markup
         r4 = true
         @index += match_len
       else
-        terminal_parse_failure('#')
+        terminal_parse_failure('\'#\'')
         r4 = nil
       end
       s3 << r4
@@ -856,7 +868,7 @@ module Markup
           r7 = true
           @index += match_len
         else
-          terminal_parse_failure(';')
+          terminal_parse_failure('\';\'')
           r7 = nil
         end
         s0 << r7
@@ -909,6 +921,9 @@ module Markup
       @index = i0
       r0 = nil
     else
+      if s0.size < 4
+        terminal_failures.pop
+      end
       r0 = instantiate_node(SyntaxNode,input, i0...index, s0)
     end
 
@@ -933,7 +948,7 @@ module Markup
       r1 = instantiate_node(SyntaxNode,input, index...(index + match_len))
       @index += match_len
     else
-      terminal_parse_failure('amp')
+      terminal_parse_failure('\'amp\'')
       r1 = nil
     end
     if r1
@@ -944,7 +959,7 @@ module Markup
         r2 = instantiate_node(SyntaxNode,input, index...(index + match_len))
         @index += match_len
       else
-        terminal_parse_failure('apos')
+        terminal_parse_failure('\'apos\'')
         r2 = nil
       end
       if r2
@@ -955,7 +970,7 @@ module Markup
           r3 = instantiate_node(SyntaxNode,input, index...(index + match_len))
           @index += match_len
         else
-          terminal_parse_failure('gt')
+          terminal_parse_failure('\'gt\'')
           r3 = nil
         end
         if r3
@@ -966,7 +981,7 @@ module Markup
             r4 = instantiate_node(SyntaxNode,input, index...(index + match_len))
             @index += match_len
           else
-            terminal_parse_failure('lt')
+            terminal_parse_failure('\'lt\'')
             r4 = nil
           end
           if r4
@@ -977,7 +992,7 @@ module Markup
               r5 = instantiate_node(SyntaxNode,input, index...(index + match_len))
               @index += match_len
             else
-              terminal_parse_failure('quot')
+              terminal_parse_failure('\'quot\'')
               r5 = nil
             end
             if r5
@@ -1014,7 +1029,7 @@ module Markup
         r1 = true
         @index += match_len
       else
-        terminal_parse_failure(' ')
+        terminal_parse_failure('\' \'')
         r1 = nil
       end
       if r1

--- a/lib/asciidoctor-pdf/formatted_text/parser.treetop
+++ b/lib/asciidoctor-pdf/formatted_text/parser.treetop
@@ -51,7 +51,7 @@ grammar Markup
     # QUESTION faster to do regex?
     # QUESTION can we cut stuff we aren't using? what about supporting hr?
     #'a' / 'b' / 'code' / 'color' / 'del' / 'em' / 'font' / 'i' / 'img' / 'link' / 'span' / 'strikethrough' / 'strong' / 'sub' / 'sup' / 'u'
-    'a' / 'code' / 'color' / 'del' / 'em' / 'font' / 'span' / 'strong' / 'sub' / 'sup'
+    'a' / 'code' / 'color' / 'del' / 'em' / 'font' / 'span' / 'strong' / 'sub' / 'sup' / 'kbd'
   end
 
   rule void_tag_name

--- a/lib/asciidoctor-pdf/formatted_text/transform.rb
+++ b/lib/asciidoctor-pdf/formatted_text/transform.rb
@@ -41,6 +41,12 @@ class Transform
     end
     @backgrounds = {}
     @overline = nil
+    @colors = {
+      white: 'ffffff', silver: 'c0c0c0', gray: '808080', black: '000000',
+      red: 'ff0000', maroon: '800000', yellow: 'ffff00', olive: '808000',
+      lime: '00ff00', green: '008000', aqua: '00ffff', teal: '008080',
+      blue: '0000ff', navy: '000080', fuchsia: 'ff00ff', purple: '800080'
+    }
   end
 
   # FIXME pass styles downwards to child elements rather than decorating on way out of hierarchy
@@ -260,12 +266,6 @@ class Transform
       end
     end
 
-    colors = {
-      white: 'ffffff', silver: 'c0c0c0', gray: '808080', black: '000000',
-      red: 'ff0000', maroon: '800000', yellow: 'ffff00', olive: '808000',
-      lime: '00ff00', green: '008000', aqua: '00ffff', teal: '008080',
-      blue: '0000ff', navy: '000080', fuchsia: 'ff00ff', purple: '800080'
-    }
     attrs.each do |key,value|
       if key == :class
         value.split.each do |field|
@@ -284,12 +284,12 @@ class Transform
             fragment[:callback].push @overline
           else
             lcfield = field.downcase.to_sym
-            if colors[lcfield] && !fragment[:color]
-              fragment[:color] = colors[lcfield]
+            if @colors[lcfield] && !fragment[:color]
+              fragment[:color] = @colors[lcfield]
             else
               m = field.match(/(.*)-background/)
               if (m)
-                bgcol = colors[m[1].downcase.to_sym]
+                bgcol = @colors[m[1].downcase.to_sym]
                 if !@backgrounds[bgcol]
                   @backgrounds[bgcol] = BackgroundCallback.new(:color => bgcol, :document => @doc)
                 end

--- a/lib/asciidoctor-pdf/formatted_text/transform.rb
+++ b/lib/asciidoctor-pdf/formatted_text/transform.rb
@@ -284,7 +284,7 @@ class Transform
             fragment[:callback].push @overline
           else
             lcfield = field.downcase.to_sym
-            if @colors[lcfield] && !fragment[:color]
+            if @colors[lcfield]
               fragment[:color] = @colors[lcfield]
             else
               m = field.match(/(.*)-background/)

--- a/lib/asciidoctor-pdf/formatted_text/transform.rb
+++ b/lib/asciidoctor-pdf/formatted_text/transform.rb
@@ -41,6 +41,7 @@ class Transform
     end
     @backgrounds = {}
     @overline = nil
+    @kbd = nil
     @colors = {
       white: 'ffffff', silver: 'c0c0c0', gray: '808080', black: '000000',
       red: 'ff0000', maroon: '800000', yellow: 'ffff00', olive: '808000',
@@ -150,6 +151,24 @@ class Transform
     end
     def render_in_front(fragment)
       @document.stroke_line ([fragment.top_left, fragment.top_right])
+    end
+  end
+
+  class KbdCallback
+    def initialize(options)
+      @document = options[:document]
+    end
+    def render_behind(fragment)
+      original_fill_color = @document.fill_color
+      original_stroke_color = @document.stroke_color
+      @document.stroke_color = 'e1dbc9';
+      @document.fill_color = 'f5f1de';
+      @document.fill_rounded_rectangle fragment.top_left, fragment.width,
+                                         fragment.height, fragment.height / 4
+      @document.stroke_rounded_rectangle fragment.top_left, fragment.width,
+                                         fragment.height, fragment.height / 4
+      @document.fill_color = original_fill_color;
+      @document.stroke_color = original_stroke_color;
     end
   end
 
@@ -264,6 +283,10 @@ class Transform
           end
         end
       end
+    when :kbd
+      @kbd ||= KbdCallback.new(:document => @doc)
+      fragment[:callback] ||= []
+            fragment[:callback].push @kbd
     end
 
     attrs.each do |key,value|


### PR DESCRIPTION
Supports all the types listed in the examples for asciidoc:
http://www.methods.co.nz/asciidoc/chunked/ch10.html
I.e. work for underline, overline, line-through, colors, big and
small.
