### PR TITLE
Remove hardcoded bold font for first line in abstract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 /pkg/
 /.ruby-gemset
 /.ruby-version
+/.idea
+

--- a/data/themes/default-theme.yml
+++ b/data/themes/default-theme.yml
@@ -125,6 +125,7 @@ abstract:
   font_size: $lead_font_size
   line_height: $lead_line_height
   font_style: italic
+  first_line_font_style: bold
 admonition:
   border_color: $base_border_color
   border_width: $base_border_width

--- a/lib/asciidoctor-pdf/converter.rb
+++ b/lib/asciidoctor-pdf/converter.rb
@@ -336,8 +336,14 @@ class Converter < ::Prawn::Document
     add_dest_for_block node if node.id
     pad_box @theme.abstract_padding do
       theme_font :abstract do
-        # FIXME control first_line_options using theme
-        prose_opts = { line_height: @theme.abstract_line_height, first_line_options: { styles: [font_style, :bold] } }
+        prose_opts = { line_height: @theme.abstract_line_height }
+        # FIXME control more first_line_options using theme
+        if (first_line_font_style = @theme.abstract_first_line_font_style)
+          first_line_font_style = first_line_font_style.to_sym
+          if ( first_line_font_style != font_style)
+            prose_opts[:first_line_options] = { styles: [font_style, first_line_font_style] }
+          end
+        end
         # FIXME make this cleaner!!
         if node.blocks?
           node.blocks.each do |child|


### PR DESCRIPTION
The feature could be re-introduced with theming support later on.
As it stands before this change, it limits the styling of abstract blocks too much.

Fixes #378.