### PR TITLE
Fix "header" content on verso side

### DIFF
--- a/docs/theming-guide.adoc
+++ b/docs/theming-guide.adoc
@@ -1707,7 +1707,7 @@ header:
   recto_content:
     center: '(C) ACME -- v{revnumber}, {docdate}'
   verso_content:
-    center: $header_recto_content
+    center: $header_recto_content_center
 footer:
   height: 0.75in
   line_height: 1


### PR DESCRIPTION
Pasting the "header" YML content doesn't work on the verso side. This patch to the theming guide gives the proper information.