### PR TITLE
resolves #479 Use its own icons for admonition block with asciidoctor…

### DIFF
--- a/lib/asciidoctor-pdf/converter.rb
+++ b/lib/asciidoctor-pdf/converter.rb
@@ -2471,8 +2471,8 @@ class Converter < ::Prawn::Document
     image_path ||= (node.attr 'target', nil, false)
     image_type ||= ::Asciidoctor::Image.image_type image_path
     # handle case when image is a URI
-    if (node.is_uri? image_path) || (imagesdir && (node.is_uri? imagesdir) &&
-        (image_path = (node.normalize_web_path image_path, imagesdir, false)))
+    if (node.is_uri? image_path) || (img_dir && (node.is_uri? img_dir) &&
+        (image_path = (node.normalize_web_path image_path, img_dir, false)))
       unless doc.attr? 'allow-uri-read'
         unless scratch?
           warn %(asciidoctor: WARNING: allow-uri-read is not enabled; cannot embed remote image: #{image_path})
@@ -2498,7 +2498,7 @@ class Converter < ::Prawn::Document
       tmp_image_path
     # handle case when image is a local file
     else
-      ::File.expand_path(node.normalize_system_path image_path, imagesdir, nil, target_name: 'image')
+      ::File.expand_path(node.normalize_system_path image_path, img_dir, nil, target_name: 'image')
     end
   end
 

--- a/lib/asciidoctor-pdf/converter.rb
+++ b/lib/asciidoctor-pdf/converter.rb
@@ -2468,7 +2468,7 @@ class Converter < ::Prawn::Document
     else
         img_dir = resolve_imagesdir(doc = node.document)
     end if
-    image_path ||= node.attr 'target'
+    image_path ||= (node.attr 'target', nil, false)
     image_type ||= ::Asciidoctor::Image.image_type image_path
     # handle case when image is a URI
     if (node.is_uri? image_path) || (imagesdir && (node.is_uri? imagesdir) &&

--- a/lib/asciidoctor-pdf/converter.rb
+++ b/lib/asciidoctor-pdf/converter.rb
@@ -2467,7 +2467,7 @@ class Converter < ::Prawn::Document
         end
     else
         img_dir = resolve_imagesdir(doc = node.document)
-    end if
+    end
     image_path ||= (node.attr 'target', nil, false)
     image_type ||= ::Asciidoctor::Image.image_type image_path
     # handle case when image is a URI

--- a/lib/asciidoctor-pdf/converter.rb
+++ b/lib/asciidoctor-pdf/converter.rb
@@ -471,7 +471,13 @@ class Converter < ::Prawn::Document
                             img = %(<img src="#{image_path}" >)
                             image_obj, image_info = build_image_object image_path                            
                             rendered_w = [bounds.width, image_info.width * 0.75].min                            
-                            rendered_h = (rendered_w * image_info.height) / image_info.width                                                       
+                            rendered_h = (rendered_w * image_info.height) / image_info.width     
+                            # If rendered_h > box_height then the icon will be misplaced in the PDF document
+                            if rendered_h > box_height
+                              ratio = box_height / rendered_h
+                              rendered_w = ratio * rendered_w
+                              rendered_h = box_height
+                            end  
                             embed_image image_obj, image_info, width: rendered_w                            
                         rescue => e
                             warn %(asciidoctor: WARNING: could not embed image: #{image_path}; #{e.message})

--- a/lib/asciidoctor-pdf/formatted_text/transform.rb
+++ b/lib/asciidoctor-pdf/formatted_text/transform.rb
@@ -15,12 +15,12 @@ class Transform
 
   def initialize(options = {})
     @merge_adjacent_text_nodes = options[:merge_adjacent_text_nodes]
-    if (@theme = options[:theme])
-      @link_font_color = @theme.link_font_color
-      @monospaced_font_color = @theme.literal_font_color
-      @monospaced_font_family = @theme.literal_font_family
-      @monospaced_font_size = @theme.literal_font_size
-      case @theme.literal_font_style
+    if (theme = options[:theme])
+      @link_font_color = theme.link_font_color
+      @monospaced_font_color = theme.literal_font_color
+      @monospaced_font_family = theme.literal_font_family
+      @monospaced_font_size = theme.literal_font_size
+      case theme.literal_font_style
       when 'bold'
         @monospaced_font_style = [:bold]
       when 'italic'
@@ -209,21 +209,6 @@ class Transform
     when :del
       styles << :strikethrough
     when :span
-        if (!attrs[:class].nil? and attrs[:class] != '')
-          pvalue = attrs[:class]
-          if pvalue.start_with? '#'
-              # hexa color code
-              pvalue = pvalue[1..-1] 
-          else
-              # color name -> get color code in the theme file (yaml)             
-              # (I deliberately add suffix _color)
-              pvalue = @theme[%(#{pvalue}_color)]
-              if pvalue.nil? or pvalue == ''
-                  pvalue = '000000'
-              end
-          end
-          fragment[:color] = pvalue           
-      end
       # span logic with normal style parsing
       if (inline_styles = attrs[:style])
         # NOTE for our purposes, spaces inside the style attribute are superfluous

--- a/lib/asciidoctor-pdf/formatted_text/transform.rb
+++ b/lib/asciidoctor-pdf/formatted_text/transform.rb
@@ -15,12 +15,12 @@ class Transform
 
   def initialize(options = {})
     @merge_adjacent_text_nodes = options[:merge_adjacent_text_nodes]
-    if (theme = options[:theme])
-      @link_font_color = theme.link_font_color
-      @monospaced_font_color = theme.literal_font_color
-      @monospaced_font_family = theme.literal_font_family
-      @monospaced_font_size = theme.literal_font_size
-      case theme.literal_font_style
+    if (@theme = options[:theme])
+      @link_font_color = @theme.link_font_color
+      @monospaced_font_color = @theme.literal_font_color
+      @monospaced_font_family = @theme.literal_font_family
+      @monospaced_font_size = @theme.literal_font_size
+      case @theme.literal_font_style
       when 'bold'
         @monospaced_font_style = [:bold]
       when 'italic'
@@ -209,6 +209,21 @@ class Transform
     when :del
       styles << :strikethrough
     when :span
+        if (!attrs[:class].nil? and attrs[:class] != '')
+          pvalue = attrs[:class]
+          if pvalue.start_with? '#'
+              # hexa color code
+              pvalue = pvalue[1..-1] 
+          else
+              # color name -> get color code in the theme file (yaml)             
+              # (I deliberately add suffix _color)
+              pvalue = @theme[%(#{pvalue}_color)]
+              if pvalue.nil? or pvalue == ''
+                  pvalue = '000000'
+              end
+          end
+          fragment[:color] = pvalue           
+      end
       # span logic with normal style parsing
       if (inline_styles = attrs[:style])
         # NOTE for our purposes, spaces inside the style attribute are superfluous


### PR DESCRIPTION
Allows to use your own images for admonition block when the variable `:icons:` is blank in the asciidoc document (images must be named `note.png`, `caution.png`, `warning.png`, `important.png`, `tip.png`, etc ...)
