### PR TITLE
fix Ruby warnings

### DIFF
--- a/asciidoctor-pdf.gemspec
+++ b/asciidoctor-pdf.gemspec
@@ -23,11 +23,11 @@ An extension for Asciidoctor that converts AsciiDoc documents to PDF using the P
   rescue
     Dir['**/*']
   end
-  s.files = files.grep /^(?:(?:data|docs|lib)\/.+|Gemfile|Rakefile|(?:CHANGELOG|LICENSE|NOTICE|README)\.adoc|#{s.name}\.gemspec)$/
+  s.files = files.grep %r/^(?:(?:data|docs|lib)\/.+|Gemfile|Rakefile|(?:CHANGELOG|LICENSE|NOTICE|README)\.adoc|#{s.name}\.gemspec)$/
   # FIXME optimize-pdf is currently a shell script, so listing it here won't work
   #s.executables = ['asciidoctor-pdf', 'optimize-pdf']
   s.executables = ['asciidoctor-pdf']
-  s.test_files = files.grep /^(?:test|spec|feature)\/.*$/
+  s.test_files = files.grep %r/^(?:test|spec|feature)\/.*$/
 
   s.require_paths = ['lib']
 

--- a/lib/asciidoctor-pdf/asciidoctor_ext/list.rb
+++ b/lib/asciidoctor-pdf/asciidoctor_ext/list.rb
@@ -5,5 +5,5 @@ class Asciidoctor::List
   # Return true if this list is an outline list. Otherwise, return false.
   def outline?
     @context == :ulist || @context == :olist
-  end unless respond_to? :outline?
+  end unless method_defined? :outline?
 end

--- a/lib/asciidoctor-pdf/asciidoctor_ext/list_item.rb
+++ b/lib/asciidoctor-pdf/asciidoctor_ext/list_item.rb
@@ -5,12 +5,12 @@ class Asciidoctor::ListItem
   # Return false if the list item contains no blocks or it contains a nested outline list. Otherwise, return true.
   def complex?
     !simple?
-  end unless respond_to? :complex?
+  end unless method_defined? :complex?
 
   # Check whether this list item has simple content (i.e., no nested blocks aside from an outline list).
   #
   # Return true if the list item contains no blocks or it contains a nested outline list. Otherwise, return false.
   def simple?
     @blocks.empty? || (@blocks.size == 1 && ::Asciidoctor::List === (blk = @blocks[0]) && blk.outline?)
-  end unless respond_to? :simple?
+  end unless method_defined? :simple?
 end

--- a/lib/asciidoctor-pdf/asciidoctor_ext/section.rb
+++ b/lib/asciidoctor-pdf/asciidoctor_ext/section.rb
@@ -18,7 +18,7 @@ class Asciidoctor::Section
       end
     end
     opts[:formal] ? @cached_formal_numbered_title : @cached_numbered_title
-  end unless respond_to? :numbered_title
+  end unless method_defined? :numbered_title
 
   def chapter?
     @document.doctype == 'book' && @level == 1 || (@special && @level == 0)

--- a/lib/asciidoctor-pdf/converter.rb
+++ b/lib/asciidoctor-pdf/converter.rb
@@ -852,7 +852,7 @@ class Converter < ::Prawn::Document
                   Border: [0, 0, 0],
                   A: { Type: :Action, S: :URI, URI: (str2pdfval link) }
             end
-            indent *overflow do
+            indent(*overflow) do
               layout_caption node, position: :bottom
             end if node.title?
           end
@@ -902,7 +902,7 @@ class Converter < ::Prawn::Document
         rescue => e
           warn %(asciidoctor: WARNING: could not embed image: #{image_path}; #{e.message})
         end
-        indent *overflow do
+        indent(*overflow) do
           layout_caption node, position: :bottom
         end if node.title?
       end

--- a/lib/asciidoctor-pdf/core_ext/array.rb
+++ b/lib/asciidoctor-pdf/core_ext/array.rb
@@ -2,10 +2,10 @@ class Array
   if RUBY_VERSION < '2.1.0'
     def to_h
       Hash[to_a]
-    end unless respond_to? :to_h
+    end unless method_defined? :to_h
   end
 
   def delete_all *entries
     entries.map {|entry| delete entry }.compact
-  end unless respond_to? :delete_all
+  end unless method_defined? :delete_all
 end

--- a/lib/asciidoctor-pdf/core_ext/numeric.rb
+++ b/lib/asciidoctor-pdf/core_ext/numeric.rb
@@ -7,5 +7,5 @@ class Numeric
     else
       self.truncate
     end
-  end unless respond_to? :with_precision
+  end unless method_defined? :with_precision
 end

--- a/lib/asciidoctor-pdf/core_ext/ostruct.rb
+++ b/lib/asciidoctor-pdf/core_ext/ostruct.rb
@@ -1,9 +1,9 @@
 class OpenStruct
   def [] key
     send key
-  end unless respond_to? :[]
+  end unless method_defined? :[]
 
   def []= key, val
     send %(#{key}=), val
-  end unless respond_to? :[]=
+  end unless method_defined? :[]=
 end if RUBY_ENGINE == 'rbx' || RUBY_VERSION < '2.0.0'

--- a/lib/asciidoctor-pdf/core_ext/string.rb
+++ b/lib/asciidoctor-pdf/core_ext/string.rb
@@ -7,5 +7,5 @@ class String
       # chars (upper alpha, lower alpha, lower greek)
       ([65, 97, 945].include? ord) ? '0' : ([ord - 1].pack 'U*')
     end
-  end unless respond_to? :pred
+  end unless method_defined? :pred
 end

--- a/lib/asciidoctor-pdf/pdf_core_ext/page.rb
+++ b/lib/asciidoctor-pdf/pdf_core_ext/page.rb
@@ -16,7 +16,7 @@ class Page
     @content = document.ref({})
     dictionary.data[:Contents] << document.state.store[@content]
     document.renderer.open_graphics_state
-  end unless respond_to? :new_content_stream
+  end unless method_defined? :new_content_stream
 end
 end
 end

--- a/lib/asciidoctor-pdf/prawn_ext/extensions.rb
+++ b/lib/asciidoctor-pdf/prawn_ext/extensions.rb
@@ -474,7 +474,7 @@ module Extensions
   #
   def span_page_width_if verdict
     if verdict
-      indent -bounds_margin_left, -bounds_margin_right do
+      indent(-bounds_margin_left, -bounds_margin_right) do
         yield
       end
     else

--- a/lib/asciidoctor-pdf/prawn_ext/font/afm.rb
+++ b/lib/asciidoctor-pdf/prawn_ext/font/afm.rb
@@ -1,4 +1,6 @@
 class Prawn::Font::AFM
+  undef_method :normalize_encoding
+
   # Patch normalize_encoding method to handle conversion more gracefully.
   #
   # Any valid utf-8 characters that cannot be encoded to windows-1252 are
@@ -9,11 +11,10 @@ class Prawn::Font::AFM
   rescue ::Encoding::UndefinedConversionError
     warn 'The following text could not be fully converted to the Windows-1252 character set:'
     warn %(#{text.gsub(/^/, '| ').rstrip})
-    warn ''
-    text.encode 'windows-1252', undef: :replace, replace: "\u00ac"
+    text.encode 'windows-1252', undef: :replace, replace: %(\u00ac)
   rescue ::Encoding::InvalidByteSequenceError
     raise Prawn::Errors::IncompatibleStringEncoding,
-          %(Your document includes text that's not compatible with the Windows-1252 character set.
-If you need full UTF-8 support, use TTF fonts instead of PDF's built-in (AFM) fonts\n.)
+          %(Your document includes text which is not compatible with the Windows-1252 character set.
+If you need full UTF-8 support, use TTF fonts instead of the built-in PDF (AFM) fonts.)
   end
 end


### PR DESCRIPTION
- use method_defined? instead of respond_to? to check if method is already defined
- add %r prefix to inline regexp when used as first argument to method
- undefine normalize_encoding method before redefining
- remove stray newline in error message in normalize_encoding method
- add parentheses where required