### PR TITLE
resolves #361 prevent visual block from spilling to next page without content

### DIFF
--- a/lib/asciidoctor-pdf/converter.rb
+++ b/lib/asciidoctor-pdf/converter.rb
@@ -992,13 +992,10 @@ class Converter < ::Prawn::Document
 
     node.subs.replace prev_subs if prev_subs
 
-    theme_margin :block, :top
+    adjusted_font_size = ((node.option? 'autofit') || (node.document.attr? 'autofit-option')) ?
+        (theme_font_size_autofit source_chunks, :code) : nil
 
-    if (node.option? 'autofit') || (node.document.attr? 'autofit-option')
-      adjusted_font_size = theme_font_size_autofit source_chunks, :code
-    else
-      adjusted_font_size = nil
-    end
+    theme_margin :block, :top
 
     keep_together do |box_height = nil|
       caption_height = node.title? ? (layout_caption node) : 0
@@ -1018,12 +1015,10 @@ class Converter < ::Prawn::Document
               bounding_box [0, cursor], width: bounds.width, height: fill_height do
                 theme_fill_and_stroke_bounds :code
                 unless b_width == 0
-                  if new_page_started
-                    indent b_radius, b_radius do
-                      # dashed line to indicate continuation from previous page
-                      stroke_horizontal_rule bg_color, line_width: b_width, line_style: :dashed
-                    end
-                  end
+                  indent b_radius, b_radius do
+                    # dashed line to indicate continuation from previous page
+                    stroke_horizontal_rule bg_color, line_width: b_width, line_style: :dashed
+                  end if new_page_started
                   if remaining_height > fill_height
                     move_down fill_height
                     indent b_radius, b_radius do

--- a/lib/asciidoctor-pdf/prawn_ext/extensions.rb
+++ b/lib/asciidoctor-pdf/prawn_ext/extensions.rb
@@ -747,10 +747,12 @@ module Extensions
     scratch.font font_family, style: font_style, size: font_size do
       scratch.instance_exec(&block)
     end
+    # NOTE don't count excess if cursor exceeds writable area (due to padding)
+    partial_page_height = [effective_page_height, start_y - scratch.y].min
     scratch.bounds.subtract_left_padding left_padding if left_padding > 0
     scratch.bounds.subtract_right_padding right_padding if right_padding > 0
     whole_pages = scratch.page_number - start_page_number
-    [(whole_pages * bounds.height + (start_y - scratch.y)), whole_pages, (start_y - scratch.y)]
+    [(whole_pages * bounds.height + partial_page_height), whole_pages, partial_page_height]
   end
 
   # Attempt to keep the objects generated in the block on the same page


### PR DESCRIPTION
- don't report a box height larger than the maximum content height
- minor code rearranging