### PR TITLE
resolves #425 allow temporary image file to be deleted

### DIFF
--- a/lib/asciidoctor-pdf/converter.rb
+++ b/lib/asciidoctor-pdf/converter.rb
@@ -864,7 +864,7 @@ class Converter < ::Prawn::Document
           # FIXME this code really needs to be better organized!
           # FIXME temporary workaround to group caption & image
           # NOTE use low-level API to access intrinsic dimensions; build_image_object caches image data previously loaded
-          image_obj, image_info = build_image_object image_path
+          image_obj, image_info = ::File.open(image_path, 'rb') {|fd| build_image_object fd }
           if width
             rendered_w, rendered_h = image_info.calc_image_dimensions width: width
           else
@@ -1688,7 +1688,7 @@ class Converter < ::Prawn::Document
       end
     end
   ensure
-    unlink_tmp_file cover_image
+    unlink_tmp_file cover_image if cover_image
   end
 
   # NOTE can't alias to start_new_page since methods have different arity
@@ -2535,6 +2535,8 @@ class Converter < ::Prawn::Document
   # NOTE Ruby 1.9 will sometimes delete a tmp file before the process exits
   def unlink_tmp_file path
     path.unlink if TemporaryPath === path && path.exist?
+  rescue => e
+    warn %(asciidoctor: WARNING: could not delete temporary image: #{path}; #{e.message})
   end
 
   # QUESTION move to prawn/extensions.rb?

--- a/lib/asciidoctor-pdf/formatted_text/inline_image_arranger.rb
+++ b/lib/asciidoctor-pdf/formatted_text/inline_image_arranger.rb
@@ -69,7 +69,7 @@ module InlineImageArranger
           fragment[:image_obj] = svg_obj
         else
           # TODO cache image info based on path (Prawn cached based on SHA1 of content)
-          image_obj, image_info = doc.build_image_object image_path
+          image_obj, image_info = ::File.open(image_path, 'rb') {|fd| doc.build_image_object fd }
           if image_w
             fragment[:image_width], fragment[:image_height] = image_info.calc_image_dimensions width: image_w
           else

--- a/lib/asciidoctor-pdf/prawn_ext/images.rb
+++ b/lib/asciidoctor-pdf/prawn_ext/images.rb
@@ -30,7 +30,7 @@ module Images
       { width: img_size.output_width, height: img_size.output_height }
     else
       # NOTE build_image_object caches image data previously loaded
-      _, img_size = build_image_object path
+      _, img_size = ::File.open(path, 'rb') {|fd| build_image_object fd }
       { width: img_size.width, height: img_size.height }
     end
   end


### PR DESCRIPTION
- don't leave file descriptor for temporary image open so it can be deleted on Windows
- warn, instead of fail, if temporary image cannot be deleted
- don't call method to unlink file if temporary image is nil