### PR TITLE
Fix specification of indentation.

### DIFF
--- a/docs/theming-guide.adoc
+++ b/docs/theming-guide.adoc
@@ -147,7 +147,7 @@ base:
     size: 12
 ----
 
-Each level of nesting must be indented by twice the amount of indentation of the parent level.
+Each level of nesting must be indented by two more spaces of indentation than the parent level.
 Also note the placement of the colon after each key name.
 
 == Values


### PR DESCRIPTION
The given description is faulty.

Let the parent's indentation be 0. Twice the parent's indentation is 0, but "2" is the expected indentation.

To quote the default theme:

```
font:
  catalog:
    NotoSerif:
      normal: notoserif-regular-latin.ttf
```

Consider the indentation of "normal". Its parent indentation is 4. According to the description, indentation 4*2 = 8 would be required, but actually 6 is expected.