### PR TITLE
Colorize footnotes

### DIFF
--- a/data/themes/base-theme.yml
+++ b/data/themes/base-theme.yml
@@ -45,6 +45,9 @@ description_list_term_font_style: normal
 description_list_term_spacing: 4
 block_margin_top: 0
 block_margin_bottom: 12
+footnote_reference_font_color: '999999'
+footnote_marker_font_color: '999999'
+footnote_text_font_color: '999999'
 caption_align: left
 caption_font_style: italic
 caption_margin_inside: 4

--- a/docs/theme-schema.json
+++ b/docs/theme-schema.json
@@ -109,6 +109,18 @@
     },
     "base_font_size_small": {
       "type": "number"
+    },
+    "footnote_reference_font_color": {
+      "$ref": "#/definitions/color",
+      "default": "#999999"
+    },
+    "footnote_marker_font_color": {
+      "$ref": "#/definitions/color",
+      "default": "#999999"
+    },
+    "footnote_text_font_color": {
+      "$ref": "#/definitions/color",
+      "default": "#999999"
     }
   }
 }

--- a/docs/theming-guide.adoc
+++ b/docs/theming-guide.adoc
@@ -1420,6 +1420,32 @@ The keys in this category control the arrangement and style of block captions.
   margin_outside: 0
 |===
 
+=== Footnotes
+
+This category covers the color of footnotes.
+
+[cols="3,4,5l"]
+|===
+|Key |Value Type |Example
+
+3+|*Key Prefix:* footnote
+
+|reference_font_color
+|<<colors,Color>>
+|caption:
+  reference_font_color: #000000
+
+|marker_font_color
+|<<colors,Color>>
+|caption:
+  marker_font_color: #999999
+
+|text_font_color
+|<<fonts,Font family name>>
+|caption:
+  text_font_color: #555555
+|===
+
 === Code
 
 The keys in this category are used to control the style of literal, listing and source blocks.

--- a/lib/asciidoctor-pdf/converter.rb
+++ b/lib/asciidoctor-pdf/converter.rb
@@ -1526,9 +1526,13 @@ class Converter < ::Prawn::Document
   end
 
   def convert_inline_footnote node
+    ref_color = @theme.footnote_reference_font_color
+    mark_color = @theme.footnote_marker_font_color
+    text_color = @theme.footnote_text_font_color
     if (index = node.attr 'index')
       #text = node.document.footnotes.find {|fn| fn.index == index }.text
-      %( <color rgb="#999999">[#{index}: #{node.text}]</color>)
+      %( <color rgb="#{mark_color}">[</color><color rgb="#{ref_color}">#{index}</color><color rgb="#{mark_color}">:</color>
+         <color rgb="#{text_color}">#{node.text}</color><color rgb="#{mark_color}">]</color>)
     elsif node.type == :xref
       # NOTE footnote reference not found
       %( <color rgb="FF0000">[#{node.text}]</color>)


### PR DESCRIPTION
**Before**

Footnotes are always rendered completely gray (#999999).

**After**

3 keys are added to the base theme, namely:

```
footnote_reference_font_color: '999999'
footnote_marker_font_color: '999999'
footnote_text_font_color: '999999'
```

which can be overridden by the user in a YAML theme file:

```
footnote:
  reference_font_color: #00FF00
  marker_font_color: #FF0000
  text_font_color: #0000FF
```

Theme extensions might require further considerations such as exchanging square bracket [] with [Japanese 【】](https://www.tofugu.com/japanese/japanese-punctuation/) or alike. But this patch implements a current usecase I have for German text. So this pull request is restricted to _colorizing_ footnotes.

Feel free to discuss 😊
