### PR TITLE
Fix toc_dot_leader_font_color theming guide documentation

### DIFF
--- a/docs/theming-guide.adoc
+++ b/docs/theming-guide.adoc
@@ -2193,11 +2193,11 @@ The keys in this category control the arrangement and style of the table of cont
   dot_leader:
     content: ". "
 
-|color
+|font_color
 |<<colors,Color>>
 |toc:
   dot_leader:
-    color: #999999
+    font_color: #999999
 |===
 
 . `<n>` is a number ranging from 1 to 6, representing each of the six heading levels.


### PR DESCRIPTION
PR #171 introduced a name change from `toc_dot_leader_color` to `toc_dot_leader_font_color`.
This change is not reflected in the theming guide.