### PR TITLE
resolves #363 transform text containing multibyte characters

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,7 @@ gemspec
 
 group :examples do
   gem 'rouge', '2.0.6'
+  # Add unicode (preferred) or activesupport to transform case of text containing multibyte chars on Ruby < 2.4
+  #gem 'activesupport', '4.2.7.1' if (Gem::Version.new RUBY_VERSION) < (Gem::Version.new '2.4.0')
+  #gem 'unicode' if (Gem::Version.new RUBY_VERSION) < (Gem::Version.new '2.4.0')
 end

--- a/docs/theming-guide.adoc
+++ b/docs/theming-guide.adoc
@@ -160,6 +160,7 @@ The value of a key may be one of the following types:
   - Alignment (left, center, right, justify)
   - Color as hex string (e.g., #ffffff)
   - Image path
+  - Enumerated type (where specified)
 * Null (clears any previously assigned value)
   - _empty_ (i.e., no value specified)
   - null
@@ -411,6 +412,19 @@ The following font styles are recognized:
 * italic
 * bold
 * bold_italic
+
+=== Text Transforms
+
+Many places where font properties can be specified, a case transformation can be applied to the text.
+The following transforms are recognized:
+
+* uppercase
+* lowercase
+* none (clears an inherited value)
+
+CAUTION: If the text contains multibyte characters (such as an accented character), and you're using Ruby < 2.4, then you must also install either the `activesupport` or `unicode` gem in order for the multibyte characters to be transformed.
+
+// Additional transforms, such as capitalize, may be added in the future.
 
 === Colors
 
@@ -1057,7 +1071,7 @@ The keys in this category control the style of most headings, including part tit
   font_style: bold
 
 |text_transform
-|none {vbar} uppercase {vbar} lowercase +
+|<<text-transforms,Text transform>> +
 (default: none)
 |heading:
   text_transform: uppercase
@@ -1113,7 +1127,7 @@ The keys in this category control the style of most headings, including part tit
   h3_font_style: bold_italic
 
 |text_transform
-|none {vbar} uppercase {vbar} lowercase +
+|<<text-transforms,Text transform>> +
 (default: $heading_text_transform)
 |heading:
   text_transform: lowercase
@@ -1172,7 +1186,7 @@ TIP: The title page can be disabled from the document by setting the `notitle` a
   font_style: bold
 
 |text_transform
-|none {vbar} uppercase {vbar} lowercase +
+|<<text-transforms,Text transform>> +
 (default: none)
 |title_page:
   text_transform: uppercase
@@ -1232,7 +1246,7 @@ TIP: The title page can be disabled from the document by setting the `notitle` a
     font_style: bold
 
 |text_transform
-|none {vbar} uppercase {vbar} lowercase +
+|<<text-transforms,Text transform>> +
 (default: none)
 |title_page:
   title:
@@ -1279,7 +1293,7 @@ TIP: The title page can be disabled from the document by setting the `notitle` a
     font_style: bold_italic
 
 |text_transform
-|none {vbar} uppercase {vbar} lowercase +
+|<<text-transforms,Text transform>> +
 (default: none)
 |title_page:
   subtitle:
@@ -1318,7 +1332,7 @@ TIP: The title page can be disabled from the document by setting the `notitle` a
     font_style: bold_italic
 
 |text_transform
-|none {vbar} uppercase {vbar} lowercase +
+|<<text-transforms,Text transform>> +
 (default: none)
 |title_page:
   authors:
@@ -1358,7 +1372,7 @@ TIP: The title page can be disabled from the document by setting the `notitle` a
     font_style: bold
 
 |text_transform
-|none {vbar} uppercase {vbar} lowercase +
+|<<text-transforms,Text transform>> +
 (default: none)
 |title_page:
   revision:
@@ -1485,7 +1499,7 @@ The keys in this category control the arrangement and style of block captions.
   font_style: italic
 
 |text_transform
-|none {vbar} uppercase {vbar} lowercase +
+|<<text-transforms,Text transform>> +
 (default: none)
 |caption:
   text_transform: uppercase
@@ -1614,7 +1628,7 @@ The keys in this category control the arrangement and style of quote blocks.
   font_style: bold
 
 |text_transform
-|none {vbar} uppercase {vbar} lowercase +
+|<<text-transforms,Text transform>> +
 (default: none)
 |blockquote:
   text_transform: uppercase
@@ -1652,7 +1666,7 @@ The keys in this category control the arrangement and style of quote blocks.
     font_style: bold
 
 |text_transform
-|none {vbar} uppercase {vbar} lowercase +
+|<<text-transforms,Text transform>> +
 (default: none)
 |blockquote:
   cite:
@@ -1709,7 +1723,7 @@ The keys in this category control the arrangement and style of sidebar blocks.
   font_size: 13
 
 |text_transform
-|none {vbar} uppercase {vbar} lowercase +
+|<<text-transforms,Text transform>> +
 (default: _inherit_)
 |sidebar:
   text_transform: uppercase
@@ -1755,7 +1769,7 @@ The keys in this category control the arrangement and style of sidebar blocks.
     font_style: bold
 
 |text_transform
-|none {vbar} uppercase {vbar} lowercase +
+|<<text-transforms,Text transform>> +
 (default: none)
 |sidebar:
   title:
@@ -1820,7 +1834,7 @@ The keys in this category control the arrangement and style of example blocks.
   font_style: italic
 
 |text_transform
-|none {vbar} uppercase {vbar} lowercase +
+|<<text-transforms,Text transform>> +
 (default: _inherit_)
 |example:
   text_transform: uppercase
@@ -1950,7 +1964,7 @@ The keys in this category control the styling of lead paragraphs.
   font_style: bold
 
 |text_transform
-|none {vbar} uppercase {vbar} lowercase +
+|<<text-transforms,Text transform>> +
 (default: none)
 |lead:
   text_transform: uppercase
@@ -1991,7 +2005,7 @@ The keys in this category control the arrangement and style of the abstract.
   font_style: italic
 
 |text_transform
-|none {vbar} uppercase {vbar} lowercase +
+|<<text-transforms,Text transform>> +
 (default: none)
 |abstract:
   text_transform: uppercase
@@ -2046,7 +2060,7 @@ The keys in this category control the arrangement and style of the abstract.
     font_style: bold
 
 |text_transform
-|none {vbar} uppercase {vbar} lowercase +
+|<<text-transforms,Text transform>> +
 (default: none)
 |abstract:
   title:
@@ -2259,7 +2273,7 @@ The keys in this category control the arrangement and style of tables and table 
     font_style: normal
 
 |text_transform
-|none {vbar} uppercase {vbar} lowercase +
+|<<text-transforms,Text transform>> +
 (default: none)
 |table:
   head:
@@ -2393,7 +2407,7 @@ The keys in this category control the arrangement and style of the table of cont
   font_style: bold
 
 |text_transform
-|none {vbar} uppercase {vbar} lowercase +
+|<<text-transforms,Text transform>> +
 (default: none)
 |toc:
   text_transform: uppercase

--- a/lib/asciidoctor-pdf/prawn_ext/extensions.rb
+++ b/lib/asciidoctor-pdf/prawn_ext/extensions.rb
@@ -419,9 +419,9 @@ module Extensions
   def transform_text text, transform
     case transform
     when :uppercase, 'uppercase'
-      upcase_pcdata text
+      uppercase_pcdata text
     when :lowercase, 'lowercase'
-      text.downcase
+      lowercase_mb text
     else
       text
     end

--- a/lib/asciidoctor-pdf/sanitizer.rb
+++ b/lib/asciidoctor-pdf/sanitizer.rb
@@ -1,3 +1,11 @@
+begin
+  require 'unicode' unless defined? Unicode::VERSION
+rescue LoadError
+  begin
+    require 'active_support/multibyte' unless defined? ActiveSupport::Multibyte
+  rescue LoadError; end
+end
+
 module Asciidoctor
 module Pdf
 module Sanitizer
@@ -25,11 +33,48 @@ module Sanitizer
         .gsub(BuiltInEntityCharRx, BuiltInEntityChars)
   end
 
-  def upcase_pcdata string
+  def uppercase_pcdata string
     if BuiltInEntityCharOrTagRx =~ string
-      string.gsub(SegmentPcdataRx) { $2 ? $2.upcase : $1 }
+      string.gsub(SegmentPcdataRx) { $2 ? (uppercase_mb $2) : $1 }
     else
+      uppercase_mb string
+    end
+  end
+
+  if RUBY_VERSION >= '2.4'
+    def uppercase_mb string
       string.upcase
+    end
+
+    def lowercase_mb string
+      string.downcase
+    end
+  # NOTE Unicode library is 4x as fast as ActiveSupport::MultiByte::Chars
+  elsif defined? ::Unicode
+    def uppercase_mb string
+      string.ascii_only? ? string.upcase : (::Unicode.upcase string)
+    end
+
+    def lowercase_mb string
+      string.ascii_only? ? string.downcase : (::Unicode.downcase string)
+    end
+  elsif defined? ::ActiveSupport::Multibyte
+    MultibyteChars = ::ActiveSupport::Multibyte::Chars
+
+    def uppercase_mb string
+      string.ascii_only? ? string.upcase : (MultibyteChars.new string).upcase.to_s
+    end
+
+    def lowercase_mb string
+      string.ascii_only? ? string.downcase : (MultibyteChars.new string).downcase.to_s
+    end
+  else
+    def uppercase_mb string
+      string.upcase
+    end
+
+    def lowercase_mb string
+      string.downcase
     end
   end
 end


### PR DESCRIPTION
- add multibyte-aware helpers methods to transform text
- if Ruby < 2.4, load Unicode or ActiveSupport::Multibyte, in that order, if available
- add section about Text Transforms in theming guide
- document how to activate multibyte transform support for Ruby < 2.4