### PR TITLE
resolves #590 use value of docdatetime & localdatetime attributes in PDF info

### DIFF
--- a/lib/asciidoctor-pdf/converter.rb
+++ b/lib/asciidoctor-pdf/converter.rb
@@ -323,8 +323,12 @@ class Converter < ::Prawn::Document
     end
     info[:Creator] = str2pdfval %(Asciidoctor PDF #{::Asciidoctor::Pdf::VERSION}, based on Prawn #{::Prawn::VERSION})
     info[:Producer] ||= (info[:Author] || info[:Creator])
-    # FIXME use docdate attribute
-    info[:ModDate] = info[:CreationDate] = ::Time.now unless doc.attr? 'reproducible'
+    unless doc.attr? 'reproducible'
+      # NOTE since we don't track the creation date of the input file, we map the ModDate header to the last modified
+      # date of the input document and the CreationDate header to the date the PDF was produced by the converter.
+      info[:ModDate] = ::Time.parse(doc.attr 'docdatetime') rescue (now ||= ::Time.now)
+      info[:CreationDate] = ::Time.parse(doc.attr 'localdatetime') rescue (now ||= ::Time.now)
+    end
     info
   end
 


### PR DESCRIPTION
- use value of docdatetime attribute to set ModDate metadata
- use value of localdatetime attribute to set CreationDate metadata