### PR TITLE
resolves #593 allow admonition label to be controlled by theme

### DIFF
--- a/data/themes/base-theme.yml
+++ b/data/themes/base-theme.yml
@@ -59,6 +59,8 @@ abstract_title_font_style: bold
 admonition_border_color: 'EEEEEE'
 admonition_border_width: 0.5
 admonition_padding: [0, 12, 0, 12]
+admonition_label_font_style: bold
+admonition_label_text_transform: uppercase
 blockquote_border_color: 'EEEEEE'
 blockquote_border_width: 4
 blockquote_padding: [6, 12, -6, 14]

--- a/data/themes/default-theme.yml
+++ b/data/themes/default-theme.yml
@@ -142,6 +142,9 @@ admonition:
   border_color: $base_border_color
   border_width: $base_border_width
   padding: [0, $horizontal_rhythm, 0, $horizontal_rhythm]
+  label:
+    text_transform: uppercase
+    font_style: bold
 #  icon:
 #    tip:
 #      name: fa-lightbulb-o

--- a/docs/theming-guide.adoc
+++ b/docs/theming-guide.adoc
@@ -1906,6 +1906,43 @@ The keys in this category control the arrangement and style of admonition blocks
 |admonition:
   padding: [0, 12, 0, 12]
 
+3+|*Key Prefix:* admonition_label, admonition_label_<name>^[1]^
+
+|font_color
+|<<colors,Color>> +
+(default: _inherit_)
+|admonition:
+  label:
+    font_color: #262626
+
+|font_family
+|<<fonts,Font family name>> +
+(default: _inherit_)
+|admonition:
+  label:
+    font_family: M+ 1p
+
+|font_size
+|<<values,Number>> +
+(default: _inherit_)
+|admonition:
+  label:
+    font_size: 12
+
+|font_style
+|<<font-styles,Font style>> +
+(default: bold)
+|admonition:
+  label:
+    font_style: bold_italic
+
+|text_transform
+|<<text-transforms,Text transform>> +
+(default: uppercase)
+|admonition:
+  label:
+    text_transform: lowercase
+
 3+|*Key Prefix:* admonition_icon_<name>^[1]^
 
 |name
@@ -1932,7 +1969,7 @@ The keys in this category control the arrangement and style of admonition blocks
 |===
 
 . `<name>` can be `note`, `tip`, `warning`, `important`, or `caution`.
-The subkeys in this category cannot be flattened (e.g., `tip_name: fa-lightbulb-o` is not valid syntax).
+The subkeys in the icon category cannot be flattened (e.g., `tip_name: fa-lightbulb-o` is not valid syntax).
 . See the `.yml` files in the https://github.com/jessedoyle/prawn-icon/tree/master/data/fonts[prawn-icon repository] for a list of valid names.
 The prefix (e.g., `fa-`) determines which font set to use.
 


### PR DESCRIPTION
- add admonition_label and admonition_label_<name> categories to theme
- default default settings for admonition labels in themes
- fix vertical alignment of admonition label using manual positioning
- don't process inline formatting in admonition label
- slightly reorg and cleanup code and comments