### PR TITLE
resolves #601 add more control over vertical rule in admonition block

### DIFF
--- a/data/themes/base-theme.yml
+++ b/data/themes/base-theme.yml
@@ -56,8 +56,8 @@ abstract_line_height: 1.4
 abstract_padding: 0
 abstract_title_align: center
 abstract_title_font_style: bold
-admonition_border_color: 'EEEEEE'
-admonition_border_width: 0.5
+admonition_column_rule_color: 'EEEEEE'
+admonition_column_rule_width: 0.5
 admonition_padding: [0, 12, 0, 12]
 admonition_label_font_style: bold
 admonition_label_text_transform: uppercase

--- a/data/themes/default-theme.yml
+++ b/data/themes/default-theme.yml
@@ -139,17 +139,17 @@ abstract:
     font_size: $heading_h4_font_size
     font_style: $heading_font_style
 admonition:
-  border_color: $base_border_color
-  border_width: $base_border_width
+  column_rule_color: $base_border_color
+  column_rule_width: $base_border_width
   padding: [0, $horizontal_rhythm, 0, $horizontal_rhythm]
+  #icon:
+  #  tip:
+  #    name: fa-lightbulb-o
+  #    stroke_color: 111111
+  #    size: 24
   label:
     text_transform: uppercase
     font_style: bold
-#  icon:
-#    tip:
-#      name: fa-lightbulb-o
-#      stroke_color: 111111
-#      size: 24
 blockquote:
   font_color: $base_font_color
   font_size: $base_font_size_large

--- a/docs/theming-guide.adoc
+++ b/docs/theming-guide.adoc
@@ -1888,17 +1888,23 @@ The keys in this category control the arrangement and style of admonition blocks
 
 3+|*Key Prefix:* admonition
 
-|border_color
+|column_rule_color
 |<<colors,Color>> +
 (default: #eeeeee)
 |admonition:
-  border_color: #eeeeee
+  column_rule_color: #aa0000
 
-|border_width
+|column_rule_style
+|solid {vbar} double {vbar} dashed {vbar} dotted +
+(default: solid)
+|admonition:
+  column_rule_style: double
+
+|column_rule_width
 |<<values,Number>> +
 (default: 0.5)
 |admonition:
-  border_width: 0.5
+  column_rule_width: 0.5
 
 |padding
 |<<measurement-units,Measurement>> {vbar} <<measurement-units,Measurement[top,right,bottom,left]>> +

--- a/lib/asciidoctor-pdf/converter.rb
+++ b/lib/asciidoctor-pdf/converter.rb
@@ -490,19 +490,24 @@ class Converter < ::Prawn::Document
           if box_height
             float do
               bounding_box [0, cursor], width: label_width + right_padding, height: box_height do
-                stroke_vertical_rule @theme.admonition_border_color, at: bounds.width
+                if (rule_color = @theme.admonition_column_rule_color) &&
+                    (rule_width = @theme.admonition_column_rule_width || @theme.base_border_width) && rule_width > 0
+                  stroke_vertical_rule rule_color,
+                      at: bounds.width,
+                      line_style: (@theme.admonition_column_rule_style || :solid).to_sym,
+                      line_width: rule_width
+                end
                 if icons
                   icon_data = admonition_icon_data label
                   icon_size = fit_icon_to_bounds icon_data[:size]
                   # NOTE Prawn's vcenter is not reliable, so calculate it manually
                   vcenter_pos = (box_height - icon_size) * 0.5
                   move_down vcenter_pos if vcenter_pos > 0
-                  icon icon_data[:name], {
-                    valign: :top,
-                    align: :center,
-                    color: icon_data[:stroke_color],
-                    size: icon_size
-                  }
+                  icon icon_data[:name],
+                      valign: :top,
+                      align: :center,
+                      color: icon_data[:stroke_color],
+                      size: icon_size
                 else
                   # IMPORTANT the label must fit in the alotted space or it shows up on another page!
                   # QUESTION anyway to prevent text overflow in the case it doesn't fit?

--- a/lib/asciidoctor-pdf/prawn_ext/extensions.rb
+++ b/lib/asciidoctor-pdf/prawn_ext/extensions.rb
@@ -619,9 +619,24 @@ module Extensions
   #
   def stroke_vertical_rule s_color = stroke_color, options = {}
     save_graphics_state do
-      line_width options[:line_width] || 0.5
+      l_at = options[:at] || 0
+      line_width(l_width = options[:line_width] || 0.5)
       stroke_color s_color
-      stroke_vertical_line bounds.bottom, bounds.top, at: (options[:at] || 0)
+      case (options[:line_style] || :solid)
+      when :solid
+        stroke_vertical_line bounds.bottom, bounds.top, at: l_at
+      when :double
+        stroke_vertical_line bounds.bottom, bounds.top, at: (l_at - l_width)
+        stroke_vertical_line bounds.bottom, bounds.top, at: (l_at + l_width)
+      when :dashed
+        dash l_width * 4
+        stroke_vertical_line bounds.bottom, bounds.top, at: l_at
+        undash
+      when :dotted
+        dash l_width
+        stroke_vertical_line bounds.bottom, bounds.top, at: l_at
+        undash
+      end
     end
   end
 

--- a/lib/asciidoctor-pdf/prawn_ext/extensions.rb
+++ b/lib/asciidoctor-pdf/prawn_ext/extensions.rb
@@ -617,54 +617,54 @@ module Extensions
   # can be specified using the line_width option. The horizontal (x)
   # position can be specified using the at option.
   #
-  def stroke_vertical_rule s_color = stroke_color, options = {}
+  def stroke_vertical_rule rule_color = stroke_color, options = {}
+    rule_x = options[:at] || 0
+    rule_y_from = bounds.top
+    rule_y_to = bounds.bottom
+    rule_style = options[:line_style]
+    rule_width = options[:line_width] || 0.5
     save_graphics_state do
-      l_at = options[:at] || 0
-      line_width(l_width = options[:line_width] || 0.5)
-      stroke_color s_color
-      case (options[:line_style] || :solid)
-      when :solid
-        stroke_vertical_line bounds.bottom, bounds.top, at: l_at
-      when :double
-        stroke_vertical_line bounds.bottom, bounds.top, at: (l_at - l_width)
-        stroke_vertical_line bounds.bottom, bounds.top, at: (l_at + l_width)
+      line_width rule_width
+      stroke_color rule_color
+      case rule_style
       when :dashed
-        dash l_width * 4
-        stroke_vertical_line bounds.bottom, bounds.top, at: l_at
-        undash
+        dash rule_width * 4
       when :dotted
-        dash l_width
-        stroke_vertical_line bounds.bottom, bounds.top, at: l_at
-        undash
-      end
+        dash rule_width
+      when :double
+        stroke_vertical_line rule_y_from, rule_y_to, at: (rule_x - rule_width)
+        rule_x += rule_width
+      end if rule_style
+      stroke_vertical_line rule_y_from, rule_y_to, at: rule_x
     end
   end
 
   # Strokes a horizontal line using the current bounds. The width of the line
   # can be specified using the line_width option.
   #
-  def stroke_horizontal_rule s_color = stroke_color, options = {}
+  def stroke_horizontal_rule rule_color = stroke_color, options = {}
+    rule_style = options[:line_style]
+    rule_width = options[:line_width] || 0.5
+    rule_x_start = bounds.left
+    rule_x_end = bounds.right
+    rule_inked = false
     save_graphics_state do
-      line_width(l_width = options[:line_width] || 0.5)
-      stroke_color s_color
-      case (options[:line_style] || :solid)
-      when :solid
-        stroke_horizontal_line bounds.left, bounds.right
-      when :double
-        move_up l_width * 1.5
-        stroke_horizontal_line bounds.left, bounds.right
-        move_down l_width * 3
-        stroke_horizontal_line bounds.left, bounds.right
-        move_up l_width * 1.5
+      line_width rule_width
+      stroke_color rule_color
+      case rule_style
       when :dashed
-        dash l_width * 4
-        stroke_horizontal_line bounds.left, bounds.right
-        undash
+        dash rule_width * 4
       when :dotted
-        dash l_width
-        stroke_horizontal_line bounds.left, bounds.right
-        undash
-      end
+        dash rule_width
+      when :double
+        move_up rule_width
+        stroke_horizontal_line rule_x_start, rule_x_end
+        move_down rule_width * 2
+        stroke_horizontal_line rule_x_start, rule_x_end
+        move_up rule_width
+        rule_inked = true
+      end if rule_style
+      stroke_horizontal_line rule_x_start, rule_x_end unless rule_inked
     end
   end
 


### PR DESCRIPTION
- add line_style (solid, double, dashed, dotted) support to stroke_vertical rule
- rename theme keys for controlling the vertical rule in an admonition block
  * admonition_border_color to admonition_column_rule_color
  * admonition_border_width to admonition_column_rule_width
- introduce theme key admonition_column_rule_style
- don't draw vertical rule in admonition block if color is nil or width is 0
- adjust indentation in code