### PR TITLE
merge PR #605

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,6 +8,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 == Unreleased
 
 * drop support for Ruby < 2.3 (and installation will fail for Ruby < 2.1)
+* add asciidoctor/pdf and asciidoctor/pdf/version require aliases
 * switch to tilde dependency versions (flexible patch number) instead of ranges
 * upgrade prawn-svg to 0.29.1; resolves numerous SVG rendering issues (#886, #430)
 * drop support for Rouge < 2

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,7 +8,8 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 == Unreleased
 
 * drop support for Ruby < 2.3 (and installation will fail for Ruby < 2.1)
-* add asciidoctor/pdf and asciidoctor/pdf/version require aliases
+* add asciidoctor/pdf and asciidoctor/pdf/version require aliases (#262)
+* rename module to Asciidoctor::PDF and define Asciidoctor::Pdf alias for backwards compatibility (#262)
 * switch to tilde dependency versions (flexible patch number) instead of ranges
 * upgrade prawn-svg to 0.29.1; resolves numerous SVG rendering issues (#886, #430)
 * drop support for Rouge < 2

--- a/asciidoctor-pdf.gemspec
+++ b/asciidoctor-pdf.gemspec
@@ -6,7 +6,7 @@ end
 
 Gem::Specification.new do |s|
   s.name = 'asciidoctor-pdf'
-  s.version = Asciidoctor::Pdf::VERSION
+  s.version = Asciidoctor::PDF::VERSION
   s.summary = 'Converts AsciiDoc documents to PDF using Asciidoctor and Prawn'
   s.description = 'An extension for Asciidoctor that converts AsciiDoc documents to PDF using the Prawn PDF library.'
   s.authors = ['Dan Allen', 'Sarah White']

--- a/asciidoctor-pdf.gemspec
+++ b/asciidoctor-pdf.gemspec
@@ -1,7 +1,7 @@
 begin
-  require_relative 'lib/asciidoctor-pdf/version'
+  require_relative 'lib/asciidoctor/pdf/version'
 rescue LoadError
-  require 'asciidoctor-pdf/version'
+  require 'asciidoctor/pdf/version'
 end
 
 Gem::Specification.new do |s|

--- a/bin/asciidoctor-pdf
+++ b/bin/asciidoctor-pdf
@@ -1,9 +1,9 @@
 #!/usr/bin/env ruby
 
-if File.file?(asciidoctor_pdf = (File.expand_path '../../lib/asciidoctor-pdf.rb', __FILE__))
+if File.file?(asciidoctor_pdf = (File.expand_path '../../lib/asciidoctor/pdf.rb', __FILE__))
   require asciidoctor_pdf
 else
-  require 'asciidoctor-pdf'
+  require 'asciidoctor/pdf'
 end
 require 'asciidoctor/cli'
 

--- a/bin/asciidoctor-pdf
+++ b/bin/asciidoctor-pdf
@@ -11,7 +11,7 @@ options = Asciidoctor::Cli::Options.new backend: 'pdf', header_footer: true
 
 # FIXME provide an API in Asciidoctor for sub-components to print version information
 unless ARGV != ['-v'] && (ARGV & ['-V', '--version']).empty?
-  $stdout.write %(Asciidoctor PDF #{Asciidoctor::Pdf::VERSION} using )
+  $stdout.write %(Asciidoctor PDF #{Asciidoctor::PDF::VERSION} using )
   # NOTE the print_version method was added in Asciidoctor 1.5.2
   if options.respond_to? :print_version
     options.print_version

--- a/lib/asciidoctor-pdf/converter.rb
+++ b/lib/asciidoctor-pdf/converter.rb
@@ -25,7 +25,7 @@ autoload :StringIO, 'stringio'
 autoload :Tempfile, 'tempfile'
 
 module Asciidoctor
-module Pdf
+module PDF
 class Converter < ::Prawn::Document
   include ::Asciidoctor::Converter
   if defined? ::Asciidoctor::Logging
@@ -414,7 +414,7 @@ class Converter < ::Prawn::Document
     }
   end
 
-  # FIXME PdfMarks should use the PDF info result
+  # FIXME Pdfmark should use the PDF info result
   def build_pdf_info doc
     info = {}
     # FIXME use sanitize: :plain_text once available
@@ -431,7 +431,7 @@ class Converter < ::Prawn::Document
     if (doc.attr? 'publisher')
       info[:Producer] = (doc.attr 'publisher').as_pdf
     end
-    info[:Creator] = %(Asciidoctor PDF #{::Asciidoctor::Pdf::VERSION}, based on Prawn #{::Prawn::VERSION}).as_pdf
+    info[:Creator] = %(Asciidoctor PDF #{::Asciidoctor::PDF::VERSION}, based on Prawn #{::Prawn::VERSION}).as_pdf
     info[:Producer] ||= (info[:Author] || info[:Creator])
     unless doc.attr? 'reproducible'
       # NOTE since we don't track the creation date of the input file, we map the ModDate header to the last modified
@@ -3566,4 +3566,5 @@ class Converter < ::Prawn::Document
 =end
 end
 end
+Pdf = PDF unless const_defined? :Pdf, false
 end

--- a/lib/asciidoctor-pdf/converter.rb
+++ b/lib/asciidoctor-pdf/converter.rb
@@ -660,7 +660,7 @@ class Converter < ::Prawn::Document
               elsif icons
                 if icon_path.end_with? '.svg'
                   begin
-                    svg_obj = ::Prawn::Svg::Interface.new ::File.read(icon_path), self,
+                    svg_obj = ::Prawn::SVG::Interface.new ::File.read(icon_path), self,
 	                    position: label_align,
                         vposition: label_valign,
                         width: label_width,
@@ -1210,7 +1210,7 @@ class Converter < ::Prawn::Document
             svg_data = ::File.read image_path
             file_request_root = ::File.dirname image_path
           end
-          svg_obj = ::Prawn::Svg::Interface.new svg_data, self,
+          svg_obj = ::Prawn::SVG::Interface.new svg_data, self,
               position: alignment,
               width: width,
               fallback_font_name: default_svg_font,
@@ -1465,11 +1465,7 @@ class Converter < ::Prawn::Document
       conum_mapping ? (restore_conums fragments, conum_mapping) : fragments
     else
       # NOTE only format if we detect a need (callouts or inline formatting)
-      if XmlMarkupRx.match? source_string
-        text_formatter.format source_string
-      else
-        [{ text: source_string }]
-      end
+      (XMLMarkupRx.match? source_string) ? (text_formatter.format source_string) : [{ text: source_string }]
     end
 
     node.subs.replace prev_subs if prev_subs
@@ -2912,7 +2908,7 @@ class Converter < ::Prawn::Document
                     begin
                       if (img_path = content[:path]).downcase.end_with? '.svg'
                         svg_data = ::File.read img_path
-                        svg_obj = ::Prawn::Svg::Interface.new svg_data, self,
+                        svg_obj = ::Prawn::SVG::Interface.new svg_data, self,
                             position: colspec[:align],
                             vposition: trim_img_valign,
                             width: content[:width],

--- a/lib/asciidoctor-pdf/formatted_text/formatter.rb
+++ b/lib/asciidoctor-pdf/formatted_text/formatter.rb
@@ -1,5 +1,5 @@
 module Asciidoctor
-module Pdf
+module PDF
 module FormattedText
 class Formatter
   if defined? ::Asciidoctor::Logging

--- a/lib/asciidoctor-pdf/formatted_text/inline_destination_marker.rb
+++ b/lib/asciidoctor-pdf/formatted_text/inline_destination_marker.rb
@@ -1,4 +1,4 @@
-module Asciidoctor::Pdf::FormattedText
+module Asciidoctor::PDF::FormattedText
 module InlineDestinationMarker
   module_function
 

--- a/lib/asciidoctor-pdf/formatted_text/inline_image_arranger.rb
+++ b/lib/asciidoctor-pdf/formatted_text/inline_image_arranger.rb
@@ -1,6 +1,6 @@
-module Asciidoctor::Pdf::FormattedText
+module Asciidoctor::PDF::FormattedText
 module InlineImageArranger
-  include ::Asciidoctor::Pdf::Measurements
+  include ::Asciidoctor::PDF::Measurements
   if defined? ::Asciidoctor::Logging
     include ::Asciidoctor::Logging
   else
@@ -14,7 +14,7 @@ module InlineImageArranger
   rescue
     PlaceholderWidthCache = {}
   end
-  TemporaryPath = ::Asciidoctor::Pdf::TemporaryPath
+  TemporaryPath = ::Asciidoctor::PDF::TemporaryPath
 
   def wrap fragments
     arrange_images fragments

--- a/lib/asciidoctor-pdf/formatted_text/inline_image_arranger.rb
+++ b/lib/asciidoctor-pdf/formatted_text/inline_image_arranger.rb
@@ -63,7 +63,7 @@ module InlineImageArranger
 
         # TODO make helper method to calculate width and height of image
         if fragment[:image_format] == 'svg'
-          svg_obj = ::Prawn::Svg::Interface.new ::File.read(image_path), doc,
+          svg_obj = ::Prawn::SVG::Interface.new ::File.read(image_path), doc,
               at: doc.bounds.top_left,
               width: image_w,
               fallback_font_name: doc.default_svg_font

--- a/lib/asciidoctor-pdf/formatted_text/inline_image_renderer.rb
+++ b/lib/asciidoctor-pdf/formatted_text/inline_image_renderer.rb
@@ -1,6 +1,6 @@
-module Asciidoctor::Pdf::FormattedText
+module Asciidoctor::PDF::FormattedText
 module InlineImageRenderer
-  TemporaryPath = ::Asciidoctor::Pdf::TemporaryPath
+  TemporaryPath = ::Asciidoctor::PDF::TemporaryPath
   module_function
 
   # Embeds the image object in this fragment into the document in place of the

--- a/lib/asciidoctor-pdf/formatted_text/inline_text_aligner.rb
+++ b/lib/asciidoctor-pdf/formatted_text/inline_text_aligner.rb
@@ -1,4 +1,4 @@
-module Asciidoctor::Pdf::FormattedText
+module Asciidoctor::PDF::FormattedText
 module InlineTextAligner
   module_function
 

--- a/lib/asciidoctor-pdf/formatted_text/parser.rb
+++ b/lib/asciidoctor-pdf/formatted_text/parser.rb
@@ -3,7 +3,7 @@
 
 
 module Asciidoctor
-module Pdf
+module PDF
 module FormattedText
 module Markup
   include Treetop::Runtime

--- a/lib/asciidoctor-pdf/formatted_text/parser.treetop
+++ b/lib/asciidoctor-pdf/formatted_text/parser.treetop
@@ -1,6 +1,6 @@
 # regenerate parser.rb using `tt parser.treetop`
 module Asciidoctor
-module Pdf
+module PDF
 module FormattedText
 grammar Markup
   rule text

--- a/lib/asciidoctor-pdf/formatted_text/transform.rb
+++ b/lib/asciidoctor-pdf/formatted_text/transform.rb
@@ -1,5 +1,5 @@
 module Asciidoctor
-module Pdf
+module PDF
 module FormattedText
 class Transform
   LF = ?\n

--- a/lib/asciidoctor-pdf/implicit_header_processor.rb
+++ b/lib/asciidoctor-pdf/implicit_header_processor.rb
@@ -1,7 +1,7 @@
 require 'asciidoctor/extensions'
 
 module Asciidoctor
-module Pdf
+module PDF
 # An include processor that skips the implicit author line below
 # the document title within include documents.
 class ImplicitHeaderProcessor < ::Asciidoctor::Extensions::IncludeProcessor
@@ -59,5 +59,5 @@ end
 end
 
 Asciidoctor::Extensions.register :pdf do
-  include_processor Asciidoctor::Pdf::ImplicitHeaderProcessor if @document.backend == 'pdf'
+  include_processor Asciidoctor::PDF::ImplicitHeaderProcessor if @document.backend == 'pdf'
 end

--- a/lib/asciidoctor-pdf/index_catalog.rb
+++ b/lib/asciidoctor-pdf/index_catalog.rb
@@ -1,4 +1,4 @@
-module Asciidoctor; module Pdf
+module Asciidoctor; module PDF
   class IndexCatalog
     LeadingAlphaRx = /^\p{Alpha}/
 

--- a/lib/asciidoctor-pdf/measurements.rb
+++ b/lib/asciidoctor-pdf/measurements.rb
@@ -1,4 +1,4 @@
-module Asciidoctor; module Pdf
+module Asciidoctor; module PDF
   module Measurements
     MeasurementValueRx = /(\d+|\d*\.\d+)(in|mm|cm|p[txc])?$/
     InsetMeasurementValueRx = /(?<=^| |\()(-?\d+(?:\.\d+)?)(in|mm|cm|p[txc])(?=$| |\))/

--- a/lib/asciidoctor-pdf/pdfmark.rb
+++ b/lib/asciidoctor-pdf/pdfmark.rb
@@ -1,7 +1,7 @@
 module Asciidoctor
-module Pdf
+module PDF
 class Pdfmark
-  include ::Asciidoctor::Pdf::Sanitizer
+  include ::Asciidoctor::PDF::Sanitizer
 
   def initialize doc
     @doc = doc
@@ -17,7 +17,7 @@ class Pdfmark
       /Keywords #{(doc.attr 'keywords').to_pdf}
       /ModDate #{date = ::Time.now.to_pdf}
       /CreationDate #{date}
-      /Creator (Asciidoctor PDF #{::Asciidoctor::Pdf::VERSION}, based on Prawn #{::Prawn::VERSION})
+      /Creator (Asciidoctor PDF #{::Asciidoctor::PDF::VERSION}, based on Prawn #{::Prawn::VERSION})
       /Producer #{(doc.attr 'publisher').to_pdf}
       /DOCINFO pdfmark
     EOS

--- a/lib/asciidoctor-pdf/prawn-svg_ext.rb
+++ b/lib/asciidoctor-pdf/prawn-svg_ext.rb
@@ -1,4 +1,4 @@
-require 'prawn-svg' unless defined? Prawn::Svg::VERSION
+require 'prawn-svg' unless defined? Prawn::SVG::Interface
 require_relative 'prawn-svg_ext/interface'
 # NOTE disable system fonts since they're non-portable
-Prawn::Svg::Interface.font_path.clear
+Prawn::SVG::Interface.font_path.clear

--- a/lib/asciidoctor-pdf/prawn-svg_ext/interface.rb
+++ b/lib/asciidoctor-pdf/prawn-svg_ext/interface.rb
@@ -1,4 +1,4 @@
-module Prawn; module Svg
+module Prawn; module SVG
   class Interface
     def resize opts = {}
       sizing = document.sizing
@@ -7,4 +7,4 @@ module Prawn; module Svg
       sizing.calculate
     end
   end
-end; end unless Prawn::Svg::Interface.method_defined? :resize
+end; end unless Prawn::SVG::Interface.method_defined? :resize

--- a/lib/asciidoctor-pdf/prawn_ext/extensions.rb
+++ b/lib/asciidoctor-pdf/prawn_ext/extensions.rb
@@ -7,8 +7,8 @@ Prawn::Icon::Compatibility.send :prepend, (::Module.new { def warning *args; end
 module Asciidoctor
 module Prawn
 module Extensions
-  include ::Asciidoctor::Pdf::Measurements
-  include ::Asciidoctor::Pdf::Sanitizer
+  include ::Asciidoctor::PDF::Measurements
+  include ::Asciidoctor::PDF::Sanitizer
 
   FontAwesomeIconSets = %w(fab far fas)
   IconSets = %w(fab far fas fi pf).to_set

--- a/lib/asciidoctor-pdf/prawn_ext/images.rb
+++ b/lib/asciidoctor-pdf/prawn_ext/images.rb
@@ -24,7 +24,7 @@ module Images
   # intrinsic width and height values (in pixels)
   def intrinsic_image_dimensions path
     if path.end_with? '.svg'
-      img_obj = ::Prawn::Svg::Interface.new ::File.read(path), self, {}
+      img_obj = ::Prawn::SVG::Interface.new ::File.read(path), self, {}
       img_size = img_obj.document.sizing
       { width: img_size.output_width, height: img_size.output_height }
     else

--- a/lib/asciidoctor-pdf/roman_numeral.rb
+++ b/lib/asciidoctor-pdf/roman_numeral.rb
@@ -28,7 +28,7 @@
 ########################################################################
 
 module Asciidoctor
-module Pdf
+module PDF
 class RomanNumeral
   BaseDigits = {
     1    => 'I',

--- a/lib/asciidoctor-pdf/rouge_ext/formatters/prawn.rb
+++ b/lib/asciidoctor-pdf/rouge_ext/formatters/prawn.rb
@@ -26,7 +26,7 @@ class Prawn < Formatter
   def initialize opts = {}
     unless ::Rouge::Theme === (theme = opts[:theme])
       unless theme && (theme = ::Rouge::Theme.find theme)
-        theme = ::Rouge::Themes::AsciidoctorPdfDefault
+        theme = ::Rouge::Themes::AsciidoctorPDFDefault
       end
       theme = theme.new
     end

--- a/lib/asciidoctor-pdf/rouge_ext/themes/asciidoctor_pdf_default.rb
+++ b/lib/asciidoctor-pdf/rouge_ext/themes/asciidoctor_pdf_default.rb
@@ -2,7 +2,7 @@ module Rouge
   module Themes
     # A variation on the pastie style from Pygments, customized for Asciidoctor PDF
     # See https://bitbucket.org/birkenfeld/pygments-main/src/default/pygments/styles/pastie.py
-    class AsciidoctorPdfDefault < CSSTheme
+    class AsciidoctorPDFDefault < CSSTheme
       name 'asciidoctor_pdf_default'
 
       # Deviate from pastie here since our italic is actually a thinner font

--- a/lib/asciidoctor-pdf/sanitizer.rb
+++ b/lib/asciidoctor-pdf/sanitizer.rb
@@ -9,7 +9,7 @@ unless RUBY_VERSION >= '2.4'
 end
 
 module Asciidoctor
-module Pdf
+module PDF
 module Sanitizer
   XmlSpecialChars = {
     '&lt;' => ?<,

--- a/lib/asciidoctor-pdf/sanitizer.rb
+++ b/lib/asciidoctor-pdf/sanitizer.rb
@@ -11,14 +11,14 @@ end
 module Asciidoctor
 module PDF
 module Sanitizer
-  XmlSpecialChars = {
+  XMLSpecialChars = {
     '&lt;' => ?<,
     '&gt;' => ?>,
     '&amp;' => ?&,
   }
-  XmlSpecialCharsRx = /(?:#{XmlSpecialChars.keys * ?|})/
-  InverseXmlSpecialChars = XmlSpecialChars.invert
-  InverseXmlSpecialCharsRx = /[#{InverseXmlSpecialChars.keys.join}]/
+  XMLSpecialCharsRx = /(?:#{XMLSpecialChars.keys * ?|})/
+  InverseXMLSpecialChars = XMLSpecialChars.invert
+  InverseXMLSpecialCharsRx = /[#{InverseXMLSpecialChars.keys.join}]/
   (BuiltInNamedEntities = {
     'amp' => ?&,
     'apos' => ?',
@@ -27,10 +27,10 @@ module Sanitizer
     'nbsp' => ' ',
     'quot' => ?",
   }).default = ??
-  XmlSanitizeRx = /<[^>]+>/
-  XmlMarkupRx = /&#?[a-z\d]+;|</
+  SanitizeXMLRx = /<[^>]+>/
+  XMLMarkupRx = /&#?[a-z\d]+;|</
   CharRefRx = /&(?:([a-z][a-z]+\d{0,2})|#(?:(\d\d\d{0,4})|x([a-f\d][a-f\d][a-f\d]{0,3})));/
-  SiftPcdataRx = /(&#?[a-z\d]+;|<[^>]+>)|([^&<]+)/
+  SiftPCDATARx = /(&#?[a-z\d]+;|<[^>]+>)|([^&<]+)/
 
   # Strip leading, trailing and repeating whitespace, remove XML tags and
   # resolve all entities in the specified string.
@@ -39,13 +39,13 @@ module Sanitizer
   # FIXME add option to control escaping entities, or a filter mechanism in general
   def sanitize string
     string.strip
-        .gsub(XmlSanitizeRx, '')
+        .gsub(SanitizeXMLRx, '')
         .tr_s(' ', ' ')
         .gsub(CharRefRx) { $1 ? BuiltInNamedEntities[$1] : [$2 ? $2.to_i : ($3.to_i 16)].pack('U1') }
   end
 
   def escape_xml string
-    string.gsub InverseXmlSpecialCharsRx, InverseXmlSpecialChars
+    string.gsub InverseXMLSpecialCharsRx, InverseXMLSpecialChars
   end
 
   def encode_quotes string
@@ -53,8 +53,8 @@ module Sanitizer
   end
 
   def uppercase_pcdata string
-    if XmlMarkupRx.match? string
-      string.gsub(SiftPcdataRx) { $2 ? (uppercase_mb $2) : $1 }
+    if XMLMarkupRx.match? string
+      string.gsub(SiftPCDATARx) { $2 ? (uppercase_mb $2) : $1 }
     else
       uppercase_mb string
     end

--- a/lib/asciidoctor-pdf/temporary_path.rb
+++ b/lib/asciidoctor-pdf/temporary_path.rb
@@ -1,5 +1,5 @@
 module Asciidoctor
-module Pdf
+module PDF
 module TemporaryPath
   def unlink
     ::File.unlink self

--- a/lib/asciidoctor-pdf/theme_loader.rb
+++ b/lib/asciidoctor-pdf/theme_loader.rb
@@ -4,9 +4,9 @@ require_relative 'core_ext/ostruct'
 require_relative 'measurements'
 
 module Asciidoctor
-module Pdf
+module PDF
 class ThemeLoader
-  include ::Asciidoctor::Pdf::Measurements
+  include ::Asciidoctor::PDF::Measurements
   if defined? ::Asciidoctor::Logging
     include ::Asciidoctor::Logging
   else

--- a/lib/asciidoctor-pdf/version.rb
+++ b/lib/asciidoctor-pdf/version.rb
@@ -1,5 +1,6 @@
 module Asciidoctor
-module Pdf
+module PDF
   VERSION = '1.5.0.alpha.17.dev'
 end
+Pdf = PDF unless const_defined? :Pdf, false
 end

--- a/lib/asciidoctor/pdf.rb
+++ b/lib/asciidoctor/pdf.rb
@@ -1,0 +1,1 @@
+require_relative '../asciidoctor-pdf'

--- a/lib/asciidoctor/pdf/version.rb
+++ b/lib/asciidoctor/pdf/version.rb
@@ -1,0 +1,1 @@
+require_relative '../../asciidoctor-pdf/version'

--- a/spec/converter_spec.rb
+++ b/spec/converter_spec.rb
@@ -1,9 +1,18 @@
 require_relative 'spec_helper'
 
-describe Asciidoctor::Pdf::Converter do
+describe Asciidoctor::PDF::Converter do
+  context 'legacy module name' do
+    it 'should map Asciidoctor::Pdf module to Asciidoctor::PDF' do
+      (expect Asciidoctor::Pdf).to be Asciidoctor::PDF
+      (expect Asciidoctor::Pdf::VERSION).to be Asciidoctor::PDF::VERSION
+      (expect Asciidoctor::Pdf::Converter).to be Asciidoctor::PDF::Converter
+      (expect Asciidoctor::Pdf::ThemeLoader).to be Asciidoctor::PDF::ThemeLoader
+    end
+  end
+
   context '.register_for' do
     it 'should self register to handle pdf backend' do
-      (expect Asciidoctor::Converter.for 'pdf').to be Asciidoctor::Pdf::Converter
+      (expect Asciidoctor::Converter.for 'pdf').to be Asciidoctor::PDF::Converter
     end
 
     it 'should convert AsciiDoc string to PDF object when backend is pdf' do
@@ -49,7 +58,7 @@ describe Asciidoctor::Pdf::Converter do
     end
 
     it 'should use theme passed in through :pdf_theme option' do
-      theme = Asciidoctor::Pdf::ThemeLoader.load_theme 'custom', fixtures_dir
+      theme = Asciidoctor::PDF::ThemeLoader.load_theme 'custom', fixtures_dir
       pdf = Asciidoctor.convert <<~'EOS', backend: 'pdf', pdf_theme: theme
       content
       EOS

--- a/spec/dests_spec.rb
+++ b/spec/dests_spec.rb
@@ -1,6 +1,6 @@
 require_relative 'spec_helper'
 
-describe 'Asciidoctor::Pdf::Converter - Dests' do
+describe 'Asciidoctor::PDF::Converter - Dests' do
   it 'should define a dest named __anchor-top at top of the first body page' do
     pdf = to_pdf <<~'EOS', doctype: 'book'
     = Document Title

--- a/spec/document_title_spec.rb
+++ b/spec/document_title_spec.rb
@@ -1,6 +1,6 @@
 require_relative 'spec_helper'
 
-describe 'Asciidoctor::Pdf::Converter - Document Title' do
+describe 'Asciidoctor::PDF::Converter - Document Title' do
   context 'book' do
     it 'should place document title on title page for doctype book' do
       pdf = to_pdf <<~'EOS', doctype: 'book', analyze: :text

--- a/spec/footnotes_spec.rb
+++ b/spec/footnotes_spec.rb
@@ -1,6 +1,6 @@
 require_relative 'spec_helper'
 
-describe 'Asciidoctor::Pdf::Converter - Footnotes' do
+describe 'Asciidoctor::PDF::Converter - Footnotes' do
   it 'should place footnotes at the end of each chapter when doctype is book' do
     pdf = to_pdf <<~'EOS', doctype: 'book', attributes: 'notitle nofooter', analyze: :text
     == Chapter A

--- a/spec/images_spec.rb
+++ b/spec/images_spec.rb
@@ -1,6 +1,6 @@
 require_relative 'spec_helper'
 
-describe 'Asciidoctor::Pdf::Converter - Images' do
+describe 'Asciidoctor::PDF::Converter - Images' do
   context 'SVG' do
     it 'should not leave gap around SVG that specifies viewBox but no width' do
       input = <<~'EOS'

--- a/spec/outline_spec.rb
+++ b/spec/outline_spec.rb
@@ -1,6 +1,6 @@
 require_relative 'spec_helper'
 
-describe 'Asciidoctor::Pdf::Converter - Outline' do
+describe 'Asciidoctor::PDF::Converter - Outline' do
   it 'should create an outline to navigate the document structure' do
     pdf = to_pdf <<~'EOS', doctype: 'book'
     = Document Title

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -1,6 +1,6 @@
 require_relative 'spec_helper'
 
-describe 'Asciidoctor::Pdf::Converter - Page' do
+describe 'Asciidoctor::PDF::Converter - Page' do
   context 'Size' do
     it 'should set page size specified by theme by default' do
       pdf = to_pdf <<~'EOS', analyze: true

--- a/spec/pdf_info_spec.rb
+++ b/spec/pdf_info_spec.rb
@@ -1,6 +1,6 @@
 require_relative 'spec_helper'
 
-describe 'Asciidoctor::Pdf::Converter - PDF Info' do
+describe 'Asciidoctor::PDF::Converter - PDF Info' do
   context 'compliance' do
     it 'should generate a PDF 1.3-compatible document' do
       (expect (to_pdf 'hello').pdf_version).to eq 1.3
@@ -11,7 +11,7 @@ describe 'Asciidoctor::Pdf::Converter - PDF Info' do
     it 'should include Asciidoctor PDF and Prawn versions in Creator field' do
       creator = (to_pdf 'hello').info[:Creator]
       (expect creator).to_not be_nil
-      (expect creator).to include %(Asciidoctor PDF #{Asciidoctor::Pdf::VERSION})
+      (expect creator).to include %(Asciidoctor PDF #{Asciidoctor::PDF::VERSION})
       (expect creator).to include %(Prawn #{Prawn::VERSION})
     end
 

--- a/spec/running_content_spec.rb
+++ b/spec/running_content_spec.rb
@@ -1,6 +1,6 @@
 require_relative 'spec_helper'
 
-describe 'Asciidoctor::Pdf::Converter - Running Content' do
+describe 'Asciidoctor::PDF::Converter - Running Content' do
   it 'should show virtual page numbers in footer by default' do
     pdf = to_pdf <<~'EOS', attributes: {}, analyze: :text
     = Document Title

--- a/spec/sections_spec.rb
+++ b/spec/sections_spec.rb
@@ -1,6 +1,6 @@
 require_relative 'spec_helper'
 
-describe 'Asciidoctor::Pdf::Converter - Sections' do
+describe 'Asciidoctor::PDF::Converter - Sections' do
   it 'should apply font size according to section level' do
     pdf = to_pdf <<~'EOS', analyze: :text
     = Document Title

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-require 'asciidoctor-pdf'
+require 'asciidoctor/pdf'
 require 'pathname'
 require 'pdf/inspector'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -125,7 +125,7 @@ RSpec.configure do |config|
     analyze = opts.delete :analyze
     opts[:attributes] = 'nofooter' unless opts.key? :attributes
     if (theme_overrides = opts.delete :theme_overrides)
-      opts[:pdf_theme] = Asciidoctor::Pdf::ThemeLoader.load_theme.tap {|theme| theme_overrides.each {|k, v| theme[k] = v } }
+      opts[:pdf_theme] = Asciidoctor::PDF::ThemeLoader.load_theme.tap {|theme| theme_overrides.each {|k, v| theme[k] = v } }
     end
     if Pathname === input
       opts[:to_dir] = output_dir unless opts.key? :to_dir

--- a/spec/tables_spec.rb
+++ b/spec/tables_spec.rb
@@ -1,6 +1,6 @@
 require_relative 'spec_helper'
 
-describe 'Asciidoctor::Pdf::Converter - Tables' do
+describe 'Asciidoctor::PDF::Converter - Tables' do
   it 'should apply frame all and grid all by default' do
     pdf = to_pdf <<~'EOS', analyze: :line
     |===

--- a/spec/text_formatter_spec.rb
+++ b/spec/text_formatter_spec.rb
@@ -1,6 +1,6 @@
 require_relative 'spec_helper'
 
-describe Asciidoctor::Pdf::FormattedText::Formatter do
+describe Asciidoctor::PDF::FormattedText::Formatter do
   context 'HTML markup' do
     it 'should format strong text' do
       output = subject.format '<strong>strong</strong>'

--- a/spec/theme_loader_spec.rb
+++ b/spec/theme_loader_spec.rb
@@ -1,6 +1,6 @@
 require_relative 'spec_helper'
 
-describe Asciidoctor::Pdf::ThemeLoader do
+describe Asciidoctor::PDF::ThemeLoader do
   subject { described_class }
 
   context '#load' do

--- a/spec/toc_spec.rb
+++ b/spec/toc_spec.rb
@@ -1,6 +1,6 @@
 require_relative 'spec_helper'
 
-describe 'Asciidoctor::Pdf::Converter - TOC' do
+describe 'Asciidoctor::PDF::Converter - TOC' do
   context 'book' do
     it 'should not generate toc by default' do
       pdf = to_pdf <<~'EOS', doctype: 'book', analyze: true


### PR DESCRIPTION
To align with RubyGems conventions:
- add asciidoctor/pdf as require alias
- rename Pdf module to PDF
- alias Pdf to PDF for backwards compatibility / convenience
- use uppercase for acronyms in constants
