### PR TITLE
resolves #614 don't leave blank page when importing PDF page

### DIFF
--- a/lib/asciidoctor-pdf/converter.rb
+++ b/lib/asciidoctor-pdf/converter.rb
@@ -885,7 +885,7 @@ class Converter < ::Prawn::Document
         (::File.readable? image_path)
       # NOTE import_page automatically advances to next page afterwards
       # QUESTION should we add destination to top of imported page?
-      return import_page image_path if image_format == 'pdf'
+      return import_page image_path, replace: page_is_empty? if image_format == 'pdf'
     else
       warn %(asciidoctor: WARNING: image to embed not found or not readable: #{image_path || target}) unless scratch?
       image_path = false

--- a/lib/asciidoctor-pdf/converter.rb
+++ b/lib/asciidoctor-pdf/converter.rb
@@ -2228,10 +2228,9 @@ class Converter < ::Prawn::Document
     end
 
     stamps = {}
-    if trim_bg_color || trim_border_color
-      # NOTE switch to first content page so stamp will get created properly (can't create on imported page)
+    if (trim_bg_color || trim_border_color) && (stamp_page_index = state.pages.index {|p| !p.imported_page? })
       prev_page_number = page_number
-      go_to_page start
+      go_to_page stamp_page_index + 1
       PageSides.each do |side|
         create_stamp trim_stamp_name[side] do
           canvas do

--- a/lib/asciidoctor-pdf/prawn_ext/extensions.rb
+++ b/lib/asciidoctor-pdf/prawn_ext/extensions.rb
@@ -703,6 +703,7 @@ module Extensions
     prev_page_size = page.size
     state.compress = false if state.compress # can't use compression if using template
     prev_text_rendering_mode = @text_rendering_mode
+    delete_page if opts[:replace]
     # NOTE use functionality provided by prawn-templates
     start_new_page_discretely template: file
     # prawn-templates sets text_rendering_mode to :unknown, which breaks running content; revert


### PR DESCRIPTION
* don't leave blank page when importing PDF page
* advance to first non-imported page when creating page stamps