### PR TITLE
resolves #621 use correct number of dots when font style is applied to toc level

### DIFF
--- a/data/themes/default-theme.yml
+++ b/data/themes/default-theme.yml
@@ -228,7 +228,7 @@ table:
   # HACK accounting for line-height
   cell_padding: [3, 3, 6, 3]
 toc:
-  dot_leader_font_color: dddddd
+  dot_leader_font_color: a9a9a9
   #dot_leader_content: '. '
   indent: $horizontal_rhythm
   line_height: 1.4

--- a/lib/asciidoctor-pdf/prawn_ext/extensions.rb
+++ b/lib/asciidoctor-pdf/prawn_ext/extensions.rb
@@ -296,6 +296,17 @@ module Extensions
     end
   end
 
+  # Retreives the collection of font styles from the given font style key,
+  # which defaults to the current font style.
+  #
+  def font_styles style = font_style
+    if style
+      style == :bold_italic ? [:bold, :italic] : [style]
+    else
+      []
+    end
+  end
+
   # Apply the font settings (family, size, styles and character spacing) from
   # the fragment to the document, then yield to the block.
   #


### PR DESCRIPTION
- do not apply font settings for toc level to dots
- calculate title and page number width in proper context
- simplify spacer