### PR TITLE
resolves #631 let theme control which toc levels have dot leaders

### DIFF
--- a/data/themes/default-theme.yml
+++ b/data/themes/default-theme.yml
@@ -228,10 +228,12 @@ table:
   # HACK accounting for line-height
   cell_padding: [3, 3, 6, 3]
 toc:
-  dot_leader_font_color: a9a9a9
-  #dot_leader_content: '. '
   indent: $horizontal_rhythm
   line_height: 1.4
+  dot_leader:
+    #content: ". "
+    font_color: a9a9a9
+    #levels: 2 3
 # NOTE in addition to footer, header is also supported
 footer:
   font_size: $base_font_size_small

--- a/docs/theming-guide.adoc
+++ b/docs/theming-guide.adoc
@@ -2583,11 +2583,21 @@ The keys in this category control the arrangement and style of the table of cont
 |toc:
   dot_leader:
     font_color: #999999
+
+|levels^[4]^
+|all {vbar} none {vbar} Integers (space-separated) +
+(default: all)
+|toc:
+  dot_leader:
+    levels: 2 3
 |===
 
 . `<n>` is a number ranging from 1 to 6, representing each of the six heading levels.
 . The `toc_title` keys inherit from level-2 heading styles, except where noted.
 . The dot leader inherits all other font properties from the root `toc` category.
+. 0-based levels (e.g., part = 0, chapter = 1).
+Dot leaders are only shown for the specified levels.
+If value is not specified, dot leaders are shown for all levels.
 
 [#running-content]
 === Running Header & Footer


### PR DESCRIPTION
- add toc_dot_leader_levels key to theme (0-based)
- default to using dot leaders for all levels
- slightly optimize how dot leaders are managed