### PR TITLE
resolves #638 don't drop anchor in text that overruns page

### DIFF
--- a/lib/asciidoctor-pdf/converter.rb
+++ b/lib/asciidoctor-pdf/converter.rb
@@ -66,6 +66,7 @@ class Converter < ::Prawn::Document
   NarrowNoBreakSpace = %(\u202f)
   ZeroWidthSpace = %(\u200b)
   HairSpace = %(\u200a)
+  DummyText = %(\u0000)
   DotLeaderTextDefault = '. '
   EmDash = %(\u2014)
   RightPointer = %(\u25ba)
@@ -1664,12 +1665,10 @@ class Converter < ::Prawn::Document
       end
     when :ref
       # NOTE destination is created inside callback registered by FormattedTextTransform#build_fragment
-      #%(<a name="#{node.target}"></a>)
-      %(<a name="#{node.target}">#{ZeroWidthSpace}</a>)
+      %(<a name="#{node.target}">#{DummyText}</a>)
     when :bibref
       # NOTE destination is created inside callback registered by FormattedTextTransform#build_fragment
-      #%(<a name="#{target = node.target}"></a>[#{target}])
-      %(<a name="#{target = node.target}">#{ZeroWidthSpace}</a>[#{target}])
+      %(<a name="#{target = node.target}">#{DummyText}</a>[#{target}])
     else
       warn %(asciidoctor: WARNING: unknown anchor type: #{node.type.inspect})
     end
@@ -1759,7 +1758,7 @@ class Converter < ::Prawn::Document
         anchor: (anchor_name = %(__term-#{node.object_id})),
         page: page_number - (node.document.attr 'pdf-pagenum-offset', 0)
       }
-      anchor = %(<a name="#{anchor_name}">#{ZeroWidthSpace}</a>)
+      anchor = %(<a name="#{anchor_name}">#{DummyText}</a>)
       if node.type == :visible
         @index.store_primary_term((visible_term = node.text), dest)
         %(#{anchor}#{visible_term})
@@ -1822,7 +1821,7 @@ class Converter < ::Prawn::Document
     end
 
     # NOTE destination is created inside callback registered by FormattedTextTransform#build_fragment
-    node.id ? %(<a name="#{node.id}">#{ZeroWidthSpace}</a>#{quoted_text}) : quoted_text
+    node.id ? %(<a name="#{node.id}">#{DummyText}</a>#{quoted_text}) : quoted_text
   end
 
   # FIXME only create title page if doctype=book!

--- a/lib/asciidoctor-pdf/formatted_text/inline_destination_marker.rb
+++ b/lib/asciidoctor-pdf/formatted_text/inline_destination_marker.rb
@@ -9,6 +9,8 @@ module InlineDestinationMarker
         # get precise position of the reference (x, y)
         dest_rect = fragment.absolute_bounding_box
         pdf.add_dest name, (pdf.dest_xyz dest_rect.first, dest_rect.last)
+        # prevent any text from being written
+        fragment.conceal
       end
     end
   end

--- a/lib/asciidoctor-pdf/formatted_text/transform.rb
+++ b/lib/asciidoctor-pdf/formatted_text/transform.rb
@@ -12,7 +12,7 @@ class Transform
   }
   CharRefRx = /&(?:#(\d{2,6})|(#{CharEntityTable.keys * '|'}));/
   TextDecorationTable = { 'underline' => :underline, 'line-through' => :strikethrough }
-  #ZeroWidthSpace = %(\u200b)
+  #DummyText = %(\u0000)
 
   def initialize(options = {})
     @merge_adjacent_text_nodes = options[:merge_adjacent_text_nodes]
@@ -58,7 +58,7 @@ class Transform
           #else
           #  # NOTE handle an empty anchor element (i.e., <a ...></a>)
           #  if (tag_name = node[:name]) == :a
-          #    fragments << build_fragment({ text: ZeroWidthSpace }, tag_name, node[:attributes])
+          #    fragments << build_fragment({ text: DummyText }, tag_name, node[:attributes])
           #    previous_fragment_is_text = false
           #  end
           end
@@ -180,7 +180,7 @@ class Transform
             $2 ? CharEntityTable[$2.to_sym] : ([$1.to_i].pack 'U*')
           } : value
         elsif (value = attrs[:name])
-          # NOTE text is ZeroWidthSpace, which is used as a placeholder so Prawn doesn't drop fragment
+          # NOTE text is null character, which is used as placeholder text so Prawn doesn't drop fragment
           fragment[:name] = value
           fragment[:callback] = InlineDestinationMarker
           visible = false


### PR DESCRIPTION
- use null character as dummy text, which Prawn doesn't strip
- conceal anchor fragment in callback to prevent null character from being written