### PR TITLE
resolves #639 record page number for index term when writing anchor

### DIFF
--- a/lib/asciidoctor-pdf/converter.rb
+++ b/lib/asciidoctor-pdf/converter.rb
@@ -184,7 +184,7 @@ class Converter < ::Prawn::Document
     #start_new_page if @ppbook && verso_page?
     start_new_page if @media == 'prepress' && verso_page?
 
-    doc.set_attr 'pdf-pagenum-offset', (num_front_matter_pages = page_number - 1)
+    num_front_matter_pages = (@index.start_page_number = page_number) - 1
     font @theme.base_font_family, size: @theme.base_font_size, style: @theme.base_font_style.to_sym
     doc.set_attr 'pdf-anchor', (doc_anchor = derive_anchor_from_id doc.id, 'top')
     add_dest_for_block doc, doc_anchor
@@ -1755,10 +1755,10 @@ class Converter < ::Prawn::Document
       node.type == :visible ? node.text : ''
     else
       dest = {
-        anchor: (anchor_name = %(__term-#{node.object_id})),
-        page: page_number - (node.document.attr 'pdf-pagenum-offset', 0)
+        anchor: (anchor_name = %(__indexterm-#{node.object_id}))
+        # NOTE page number is added in InlineDestinationMarker
       }
-      anchor = %(<a name="#{anchor_name}">#{DummyText}</a>)
+      anchor = %(<a name="#{anchor_name}" type="indexterm">#{DummyText}</a>)
       if node.type == :visible
         @index.store_primary_term((visible_term = node.text), dest)
         %(#{anchor}#{visible_term})

--- a/lib/asciidoctor-pdf/formatted_text/inline_destination_marker.rb
+++ b/lib/asciidoctor-pdf/formatted_text/inline_destination_marker.rb
@@ -6,6 +6,9 @@ module InlineDestinationMarker
   def render_behind fragment
     unless (pdf = fragment.document).scratch?
       if (name = fragment.format_state[:name])
+        if fragment.format_state[:type] == :indexterm
+          (pdf.instance_variable_get :@index).link_dest_to_page name, pdf.page_number
+        end
         # get precise position of the reference (x, y)
         dest_rect = fragment.absolute_bounding_box
         pdf.add_dest name, (pdf.dest_xyz dest_rect.first, dest_rect.last)

--- a/lib/asciidoctor-pdf/formatted_text/transform.rb
+++ b/lib/asciidoctor-pdf/formatted_text/transform.rb
@@ -182,6 +182,9 @@ class Transform
         elsif (value = attrs[:name])
           # NOTE text is null character, which is used as placeholder text so Prawn doesn't drop fragment
           fragment[:name] = value
+          if (type = attrs[:type])
+            fragment[:type] = type.to_sym
+          end
           fragment[:callback] = InlineDestinationMarker
           visible = false
         end


### PR DESCRIPTION
- record page number for index term when destination for anchor is written
- maintain an internal table of the index term destinations
- filter destinations that don't have a page number assigned