### PR TITLE
resolves #674 add support for absolute measurement units to scaledwidth attribute

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -298,10 +298,13 @@ There are five ways to specify the width of an image, listed here in order of pr
 
 |pdfwidth
 |The display width of the image as an absolute size (e.g., 2in), percentage of the content area width (e.g., 75%), or percentage of the page width (e.g., 100vw).
+If a unit of measurement is not specified (or not recognized), pt (points) is assumed.
 _Intended to be used for the PDF converter only._
 
 |scaledwidth
-|The display width of the image as a percentage of the content area width (e.g., 75%).
+|The display width of the image as an absolute size (e.g., 2in) or percentage of the content area width (e.g., 75%).
+If a unit of measurement is not specified, % (percentage) is assumed.
+If a unit of measurement is recognized, pt (points) is assumed.
 _Intended to be used for print output such as PDF._
 
 |image_width key from theme
@@ -313,14 +316,14 @@ _Only applies to block images._
 If the width exceeds the content area width, the image is scaled down to the content area width.
 
 |_unspecified_
-|If you don't specify one of the aforementioned width settings, the intrinsic width of the image is used (the px value is multiplied by 75% to convert to pt) unless the width exceeds the content area width, in which case the image is scaled down to the content area width.
+|If you don't specify one of the aforementioned width settings, the intrinsic width of the image is used (the px value is multiplied by 75% to convert to pt, assuming canvas is 96 dpi) unless the width exceeds the content area width, in which case the image is scaled down to the content area width.
 |===
 
 The image is always sized according to the explicit or intrinsic width and its height is scaled proporationally.
 The height of the image is ignored by the PDF converter unless the height of the image exceeds the content height of the page.
 In this case, the image is scaled down to fit on a single page.
 
-Images within running content also support the `fit` attribute.
+Images in running content also support the `fit` attribute.
 If the value of this attribute is `contain`, the image size is increased or decreased to fill the available space while preserving its aspect ratio.
 If the value of this attribute is `scaled-down`, the image size is first resolved in the normal way, then scaled down further to fit within the available space, if necessary.
 
@@ -338,14 +341,15 @@ The pdfwidth attribute supports the following units:
 * cm
 * mm
 * px
+* pc
 * vw (percentage of page width)
 * % (percentage of content area width)
 
 In all cases, the width is converted to pt.
 
-=== Specifying a default pdfwidth
+=== Specifying a default width
 
-If you want to scale all block images that don't have a pdfwidth (or scaledwidth) attribute the same, assign a value to the image_width key in your theme.
+If you want to scale all block images that don't have a pdfwidth or scaledwidth attribute specified, assign a value to the image_width key in your theme.
 
 [source,yaml]
 ----
@@ -359,7 +363,7 @@ Inline images are handled different than block images.
 In particular, inline images do not support sizing using the pdfwidth attribute.
 
 Here's how an inline image is sized.
-The image height is scaled down to 75% of the specified width (px to pt conversion).
+The image height is scaled down to 75% of the specified width (px to pt conversion, assuming canvas is 96 dpi).
 If the image height is more than 1.5x the height of the surrounding line of text, the font size and line metrics of the fragment are modified to fit the image in the line.
 
 == Printing

--- a/lib/asciidoctor-pdf/converter.rb
+++ b/lib/asciidoctor-pdf/converter.rb
@@ -82,8 +82,8 @@ class Converter < ::Prawn::Document
     unchecked: %(\u2610)
   }
   SimpleAttributeRefRx = /(?<!\\)\{\w+(?:[\-]\w+)*\}/
-  MeasurementRxt = '\\d+(?:\\.\\d+)?(?:in|cm|mm|pt|px)?'
-  MeasurementPartsRx = /^(\d+(?:\.\d+)?)(in|mm|cm|pt|px)?$/
+  MeasurementRxt = '\\d+(?:\\.\\d+)?(?:in|cm|mm|p[txc])?'
+  MeasurementPartsRx = /^(\d+(?:\.\d+)?)(in|mm|cm|p[txc])?$/
   PageSizeRx = /^(?:\[(#{MeasurementRxt}), ?(#{MeasurementRxt})\]|(#{MeasurementRxt})(?: x |x)(#{MeasurementRxt})|\S+)$/
   # CalloutExtractRx synced from /lib/asciidoctor.rb of Asciidoctor core
   CalloutExtractRx = /(?:(?:\/\/|#|--|;;) ?)?(\\)?<!?(--|)(\d+)\2> ?(?=(?:\\?<!?\2\d+\2> ?)*$)/
@@ -3028,7 +3028,12 @@ class Converter < ::Prawn::Document
         str_to_pt width
       end
     elsif attrs.key? 'scaledwidth'
-      (attrs['scaledwidth'].to_f / 100) * max_width
+      # NOTE the parser automatically appends % if value is unitless
+      if (width = attrs['scaledwidth']).end_with? '%'
+        (width.to_f / 100) * max_width
+      else
+        str_to_pt width
+      end
     elsif opts[:use_fallback] && (width = @theme.image_width)
       if width.end_with? '%'
         (width.to_f / 100) * max_width

--- a/lib/asciidoctor-pdf/prawn_ext/extensions.rb
+++ b/lib/asciidoctor-pdf/prawn_ext/extensions.rb
@@ -9,7 +9,7 @@ module Extensions
   include ::Asciidoctor::Pdf::Sanitizer
 
   IconSets = ['fa', 'fi', 'octicon', 'pf'].to_set
-  MeasurementValueRx = /(\d+|\d*\.\d+)(in|mm|cm|px|pt)?$/
+  MeasurementValueRx = /(\d+|\d*\.\d+)(in|mm|cm|p[txc])?$/
   InitialPageContent = %(q\n)
 
   # - :height is the height of a line
@@ -168,23 +168,26 @@ module Extensions
       when 'cm'
         num * (720 / 25.4)
       when 'px'
+        # assuming canvas of 96 dpi
         num * 0.75
+      when 'pc'
+        num * 12
       end
     end
   end
 
   # Convert the specified string value to a pt value from the
   # specified unit of measurement (e.g., in, cm, mm, etc).
+  # If the unit of measurement is not recognized, assume pt.
   #
   # Examples:
   #
   #  0.5in => 36.0
   #  100px => 75.0
+  #  72blah => 72.0
   #
   def str_to_pt val
-    if MeasurementValueRx =~ val
-      to_pt $1.to_f, $2
-    end
+    MeasurementValueRx =~ val ? (to_pt $1.to_f, $2) : val.to_f
   end
 
   # Destinations

--- a/lib/asciidoctor-pdf/theme_loader.rb
+++ b/lib/asciidoctor-pdf/theme_loader.rb
@@ -14,7 +14,7 @@ class ThemeLoader
   VariableRx = /\$([a-z0-9_]+)/
   LoneVariableRx = /^\$([a-z0-9_]+)$/
   HexColorEntryRx = /^(?<k>[[:blank:]]*[[:graph:]]+): +(?!null$)(?<q>["']?)#?(?<v>\w{3,6})\k<q> *(?:#.*)?$/
-  MeasurementValueRx = /(?<=^| |\()(-?\d+(?:\.\d+)?)(in|mm|cm|pt|px)(?=$| |\))/
+  MeasurementValueRx = /(?<=^| |\()(-?\d+(?:\.\d+)?)(in|mm|cm|p[txc])(?=$| |\))/
   MultiplyDivideOpRx = /(-?\d+(?:\.\d+)?) +([*\/]) +(-?\d+(?:\.\d+)?)/
   AddSubtractOpRx = /(-?\d+(?:\.\d+)?) +([+\-]) +(-?\d+(?:\.\d+)?)/
   PrecisionFuncRx = /^(round|floor|ceil)\(/
@@ -149,7 +149,7 @@ class ThemeLoader
     # QUESTION should we round the value? perhaps leave that to the precision functions
     # NOTE leave % as a string; handled by converter for now
     expr = expr.gsub(MeasurementValueRx) {
-      # TODO extract to_pt method and use it here
+      # FIXME use to_pt method from Prawn extensions
       val = $1.to_f
       case $2
       when 'in'
@@ -159,7 +159,10 @@ class ThemeLoader
       when 'cm'
         val * (720 / 25.4)
       when 'px'
+        # assuming canvas of 96 dpi
         val * 0.75
+      when 'pc'
+        val * 12
       else
         val # default unit is pt
       end


### PR DESCRIPTION
- add support for absolute measurement units to value of scaledwidth attribute
- add support for pc (pica) units
- update docs to explain px to pt conversion in more detail
- make str_to_pt method resort to pt units if units aren't recognized
- comments