### PR TITLE
backport resize method from prawn-svg and use it

### DIFF
--- a/lib/asciidoctor-pdf/prawn-svg_ext.rb
+++ b/lib/asciidoctor-pdf/prawn-svg_ext.rb
@@ -1,0 +1,4 @@
+require 'prawn-svg' unless defined? Prawn::Svg::VERSION
+require_relative 'prawn-svg_ext/interface'
+# NOTE disable system fonts since they're non-portable
+Prawn::Svg::Interface.font_path.clear

--- a/lib/asciidoctor-pdf/prawn-svg_ext/interface.rb
+++ b/lib/asciidoctor-pdf/prawn-svg_ext/interface.rb
@@ -1,0 +1,10 @@
+module Prawn; module Svg
+  class Interface
+    def resize opts = {}
+      sizing = document.sizing
+      sizing.requested_width = opts[:width]
+      sizing.requested_height = opts[:height]
+      sizing.calculate
+    end
+  end
+end; end unless Prawn::Svg::Interface.method_defined? :resize


### PR DESCRIPTION
- backport resize method
- simplify calls to Prawn::Svg::Interface
- move loading and patching of prawn-svg into prawn-svg_ext