### PR TITLE
Fixes #259 - Sidebars now render on multiple pages

### DIFF
--- a/lib/asciidoctor-pdf/converter.rb
+++ b/lib/asciidoctor-pdf/converter.rb
@@ -698,18 +698,52 @@ class Converter < ::Prawn::Document
     add_dest_for_block node if node.id
     theme_margin :block, :top
     keep_together do |box_height = nil|
-      if box_height
-        float do
-          bounding_box [0, cursor], width: bounds.width, height: box_height do
-            theme_fill_and_stroke_bounds :sidebar
-          end
-        end
-      end
+      start_page_number = page_number
+      start_cursor = cursor
+      # FIXME? Have to draw graphics once before content to get accurate box_height.
+      # This is overwritten by the theme_fill_and_stroke_bounds command, so needs drawing twice
       pad_box @theme.sidebar_padding do
         if node.title?
           theme_font :sidebar_title do
             # QUESTION should we allow margins of sidebar title to be customized?
-            layout_heading node.title, align: (@theme.sidebar_title_align || @base_align).to_sym, margin_top: 0
+            layout_heading node.title, align: (@theme.sidebar_title_align || @theme.base_align).to_sym, margin_top: 0
+          end
+        end
+        theme_font :sidebar do
+          convert_content_for_block node
+        end
+      end
+      
+      if box_height
+        page_spread = (end_page_number = page_number) - start_page_number + 1
+        end_cursor = cursor
+        go_to_page start_page_number
+        move_cursor_to start_cursor
+        page_spread.times do |i|
+          if i == 0
+            y_draw = cursor
+            b_height = page_spread > 1 ? y_draw : (y_draw - end_cursor)
+          else
+            bounds.move_past_bottom
+            y_draw = cursor
+            b_height = page_spread - 1 == i ? (y_draw - end_cursor) : y_draw
+          end
+          bounding_box [0, y_draw], width: bounds.width, height: b_height do
+            theme_fill_and_stroke_bounds :sidebar
+          end
+        end
+      end
+      
+      go_to_page start_page_number
+      move_cursor_to start_cursor
+      pad_box @theme.sidebar_padding do
+        if node.title?
+          theme_font :sidebar_title do
+            # HACK: The "margin_top: 1" makes things work, but I don't know entirely why.
+            # Using the blockquote_padding above instead of sidebar_padding makes the blocks render with the wrong padding.
+            # Using the sidebar_padding it loses the background on subsequent pages unless margin_top is 1 here.
+            # QUESTION should we allow margins of sidebar title to be customized? 
+            layout_heading node.title, align: (@theme.sidebar_title_align || @theme.base_align).to_sym, margin_top: 1
           end
         end
         theme_font :sidebar do


### PR DESCRIPTION
Refactored convert_sidebar to mirror behaviour of convert_quote_or_verse, such that multiple pages draw correctly. Requires drawing the block content twice, and there's a small hack, but it works.

I coded this just to get something working, but happy to accept edits - I am using as-is at the moment and seems to work as expected.

Fixes #259 