### PR TITLE
resolves #724 introduce attribute to control table striping

### DIFF
--- a/data/themes/default-theme.yml
+++ b/data/themes/default-theme.yml
@@ -222,8 +222,8 @@ table:
   #head_background_color: <hex value>
   #head_font_color: $base_font_color
   head_font_style: bold
-  even_row_background_color: f9f9f9
-  #odd_row_background_color: <hex value>
+  #body_background_color: <hex value>
+  body_stripe_background_color: f9f9f9
   foot_background_color: f0f0f0
   border_color: dddddd
   border_width: $base_border_width

--- a/lib/asciidoctor-pdf/converter.rb
+++ b/lib/asciidoctor-pdf/converter.rb
@@ -1408,8 +1408,12 @@ class Converter < ::Prawn::Document
     # NOTE emulate table bg color by using it as a fallback value for each element
     head_bg_color = resolve_theme_color :table_head_background_color, tbl_bg_color
     foot_bg_color = resolve_theme_color :table_foot_background_color, tbl_bg_color
-    odd_row_bg_color = resolve_theme_color :table_odd_row_background_color, tbl_bg_color
-    even_row_bg_color = resolve_theme_color :table_even_row_background_color, tbl_bg_color
+    body_bg_color = resolve_theme_color :table_body_background_color,
+        # table_odd_row_background_color is deprecated
+        (resolve_theme_color :table_odd_row_background_color, tbl_bg_color)
+    body_stripe_bg_color = resolve_theme_color :table_body_stripe_background_color,
+        # table_even_row_background_color is deprecated
+        (resolve_theme_color :table_even_row_background_color, tbl_bg_color)
 
     table_data = []
     node.rows[:head].each do |row|
@@ -1594,9 +1598,20 @@ class Converter < ::Prawn::Document
         border_color: theme.table_grid_color || theme.table_border_color || theme.base_border_color
       },
       width: table_width,
-      column_widths: column_widths,
-      row_colors: [odd_row_bg_color, even_row_bg_color]
+      column_widths: column_widths
     }
+
+    # QUESTION should we support nth; should we support sequence of roles?
+    case (stripe = node.attr 'stripe', 'even', false)
+    when 'all'
+      table_settings[:row_colors] = [body_stripe_bg_color]
+    when 'even'
+      table_settings[:row_colors] = [body_bg_color, body_stripe_bg_color]
+    when 'odd'
+      table_settings[:row_colors] = [body_stripe_bg_color, body_bg_color]
+    else # none
+      table_settings[:row_colors] = [body_bg_color]
+    end
 
     theme_margin :block, :top
 


### PR DESCRIPTION
- add stripe role to control table striping
- values are even (default), odd, all, none
- introduce keys to control striping
- table_body_background_color is "off" value; odd rows by default
- table_body_stripe_background_color is "on" value; even rows by default