### PR TITLE
resolves #755 enable "start inline" option when highlighting PHP

### DIFF
--- a/lib/asciidoctor-pdf/converter.rb
+++ b/lib/asciidoctor-pdf/converter.rb
@@ -1208,6 +1208,7 @@ class Converter < ::Prawn::Document
         stripnl: false,
         style: (style = (node.document.attr 'pygments-style') || 'pastie')
       }
+      lexer_opts[:startinline] = !(node.option? 'mixed') if lexer.name == 'PHP'
       # TODO enable once we support background color on spans
       #if node.attr? 'highlight', nil, false
       #  unless (hl_lines = node.resolve_lines_to_highlight(node.attr 'highlight', nil, false)).empty?
@@ -1233,13 +1234,14 @@ class Converter < ::Prawn::Document
     when 'rouge'
       Helpers.require_library RougeRequirePath, 'rouge' unless defined? ::Rouge::Formatters::Prawn
       lexer = ::Rouge::Lexer.find(node.attr 'language', 'text', false) || ::Rouge::Lexers::PlainText
+      lexer_opts = lexer.tag == 'php' ? { start_inline: !(node.option? 'mixed') } : {}
       formatter = (@rouge_formatter ||= ::Rouge::Formatters::Prawn.new theme: (node.document.attr 'rouge-style'), line_gap: @theme.code_line_gap)
       formatter_opts = (node.attr? 'linenums') ? { line_numbers: true, start_line: (node.attr 'start').to_i } : {}
       # QUESTION allow border color to be set by theme for highlighted block?
       bg_color_override = formatter.background_color
       source_string, conum_mapping = extract_conums source_string
       # NOTE trailing endline is added to address https://github.com/jneen/rouge/issues/279
-      fragments = formatter.format (lexer.lex %(#{source_string}#{LF})), formatter_opts
+      fragments = formatter.format (lexer.lex %(#{source_string}#{LF}), lexer_opts), formatter_opts
       # NOTE cleanup trailing endline (handled in rouge_ext/formatters/prawn instead)
       #fragments.last[:text] == LF ? fragments.pop : fragments.last[:text].chop!
       conum_mapping ? (restore_conums fragments, conum_mapping) : fragments


### PR DESCRIPTION
- enable "start inline" option when highlighting PHP by default
- disable setting if the mixed option is set on source block