### PR TITLE
Update Prawn::Icon

### DIFF
--- a/asciidoctor-pdf.gemspec
+++ b/asciidoctor-pdf.gemspec
@@ -46,7 +46,7 @@ An extension for Asciidoctor that converts AsciiDoc documents to PDF using the P
   s.add_runtime_dependency 'prawn-templates', '>= 0.0.3', '<= 0.1.1'
   # prawn-svg >= 0.22.1 requires Ruby >= 2.0.0, so we must cast a wider net to support Ruby 1.9.3
   s.add_runtime_dependency 'prawn-svg', '>= 0.21.0', '< 0.28.0'
-  s.add_runtime_dependency 'prawn-icon', '1.3.0'
+  s.add_runtime_dependency 'prawn-icon', '1.4.0'
   s.add_runtime_dependency 'safe_yaml', '~> 1.0.4'
   s.add_runtime_dependency 'thread_safe', '~> 0.3.6'
   # For our usage, treetop 1.6.2 is slower than 1.5.3


### PR DESCRIPTION
Hi there!

I just wanted to send in this patch to update `prawn-icon` from version `1.3.0` to `1.4.0`.

This version updates the `octicon`, `font-awesome` and `payment-font` fonts all to their current latest versions.

See the [changelog](https://github.com/jessedoyle/prawn-icon/blob/master/CHANGELOG.md) for more details!