### PR TITLE
fix table caption position when alignment is center

### DIFF
--- a/lib/asciidoctor-pdf/converter.rb
+++ b/lib/asciidoctor-pdf/converter.rb
@@ -2326,7 +2326,7 @@ class Converter < ::Prawn::Document
   # Render the caption for a table and return the height of the rendered content
   def layout_table_caption node, width, alignment = :left, side = :top
     # QUESTION should we confine width of title to width of table?
-    if alignment == :left || (excess = bounds.width - width) == 0
+    if [:left, :center].include?(alignment) || (excess = bounds.width - width) == 0
       layout_caption node, side: side
     else
       indent excess * (alignment == :center ? 0.5 : 1) do


### PR DESCRIPTION
related issue #823

style.yml
```yml
caption:
  align: center
```

### before
![image](https://user-images.githubusercontent.com/25898373/43312650-e81afab8-91c8-11e8-9cc4-f652e898cdd8.png)

### after 
![image](https://user-images.githubusercontent.com/25898373/43311976-edbf4fca-91c6-11e8-8254-0b2cef7fc867.png)