### PR TITLE
resolves #606 allow running content to be added to toc and title pages

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -10,6 +10,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 * drop support for Ruby < 2.3 (and installation will fail for Ruby < 2.1)
 * switch to tilde dependency versions (flexible patch number) instead of ranges
 * upgrade prawn-svg to 0.29.1; resolves numerous SVG rendering issues (#886, #430)
+* allow running content (header and footer) to be enabled on title and toc pages; controlled by running_content_start_at property in theme (#606)
 * allow additional style properties to be set per heading level (#176) (@billybooth)
 * set line spacing for non-AsciiDoc table cells (#296)
 * consider all scripts when looking for leading alpha characters in index (#853)

--- a/docs/theming-guide.adoc
+++ b/docs/theming-guide.adoc
@@ -3149,6 +3149,13 @@ The keys in this category control the arrangement and style of running header an
 |===
 |Key |Value Type |Example
 
+3+|[#key-prefix-running_content]*Key Prefix:* <<key-prefix-running_content,running_content>>
+|start_at
+|title {vbar} toc {vbar} body +
+(default: body)
+|running_content:
+  start_at: toc
+
 3+|[#key-prefix-header]*Key Prefix:* <<key-prefix-header,header>>
 
 |background_color^[1]^


### PR DESCRIPTION
Theme setup:

```
header:
    startfrom: title|toc

footer:
    startfrom: title|toc
```

https://github.com/asciidoctor/asciidoctor-pdf/issues/606