### PR TITLE
resolves #947 prevent tempfile for remote image from being deleted before it's used

### DIFF
--- a/lib/asciidoctor-pdf/converter.rb
+++ b/lib/asciidoctor-pdf/converter.rb
@@ -23,7 +23,7 @@ require_relative 'roman_numeral'
 require_relative 'index_catalog'
 
 autoload :StringIO, 'stringio'
-autoload :Tempfile, 'tempfile'
+autoload :Tempfile, ::File.join((::File.dirname __FILE__), 'core_ext/tempfile')
 
 module Asciidoctor
 module Pdf
@@ -228,6 +228,7 @@ class Converter < ::Prawn::Document
     catalog.data[:ViewerPreferences] = { DisplayDocTitle: true }
 
     layout_cover_page :back, doc
+    nil
   end
 
   # NOTE embedded only makes sense if perhaps we are building
@@ -3203,7 +3204,7 @@ class Converter < ::Prawn::Document
     image_format ||= ::Asciidoctor::Image.format image_path, (::Asciidoctor::Image === node ? node : nil)
     # NOTE currently used for inline images
     if ::Base64 === image_path
-      tmp_image = ::Tempfile.new ['image-', image_format && %(.#{image_format})]
+      tmp_image = ::Tempfile.create ['image-', image_format && %(.#{image_format})]
       tmp_image.binmode unless image_format == 'svg'
       begin
         tmp_image.write(::Base64.decode64 image_path)
@@ -3225,7 +3226,7 @@ class Converter < ::Prawn::Document
       else
         ::OpenURI
       end
-      tmp_image = ::Tempfile.new ['image-', image_format && %(.#{image_format})]
+      tmp_image = ::Tempfile.create ['image-', image_format && %(.#{image_format})]
       tmp_image.binmode if (binary = image_format != 'svg')
       begin
         open(image_path, (binary ? 'rb' : 'r')) {|fd| tmp_image.write fd.read }

--- a/lib/asciidoctor-pdf/core_ext/tempfile.rb
+++ b/lib/asciidoctor-pdf/core_ext/tempfile.rb
@@ -1,0 +1,46 @@
+require 'tempfile'
+
+# The purpose of this code is strictly to backport the Tempfile.create method
+# from Ruby, which became available in the 2.1.0 version of the language. This
+# backport does not introduce any new functionality.
+#
+# The code in this file has been adapted from the lib/tempfile.rb and
+# lib/tmpdir.rb source files in the C Ruby implementation, which is licensed
+# under the terms of the 2-clause BSD license. You can obtain the original
+# source from the C Ruby 2.5 distribution or
+# https://github.com/ruby/ruby/blob/ruby_2_5/lib/tempfile.rb and
+# https://github.com/ruby/ruby/blob/ruby_2_5/lib/tmpdir.rb, respectively.
+
+class Tempfile
+  if RUBY_VERSION < '2.1.0'
+    FILE_SEPARATORS = %(#{::File::SEPARATOR}#{::File::ALT_SEPARATOR})
+
+    def self.create basename = '', tmpdir = nil, options = {}
+      tmpfile = nil
+      mode = (options.delete :mode) || 0
+      create_tmpname basename, tmpdir, options do |tmppath, n, opts|
+        tmpfile = ::File.open tmppath, (mode |= ::File::RDWR | ::File::CREAT | ::File::EXCL), (opts.merge perm: 0600)
+      end
+      tmpfile
+    end unless respond_to? :create
+
+    def self.create_tmpname basename, tmpdir = nil, options = {}
+      tmpdir ||= ::Dir.tmpdir
+      max_try = options.delete :max_try
+      n = nil
+      prefix, suffix = basename
+      prefix = prefix.delete FILE_SEPARATORS
+      suffix = suffix ? (suffix.delete FILE_SEPARATORS) : ''
+      now = ::Time.now.strftime '%Y%m%d'
+      begin
+        path = ::File.join tmpdir, %(#{prefix}#{now}-#{$$}-#{(rand 0x100000000).to_s 36}#{n ? "-#{n}" : ''}#{suffix})
+        yield path, n, options
+      rescue ::Errno::EEXIST
+        n = (n || 0) + 1
+        retry if !max_try or n < max_try
+        raise %(cannot generate temporary name using `#{basename}' under `#{tmpdir}')
+      end
+      path
+    end
+  end
+end


### PR DESCRIPTION
- replace Tempfile.new with Tempfile.create
- implement Tempfile.create for Ruby < 2.1.0