### PR TITLE
resolves #828 add support for SVG admonition icons

### DIFF
--- a/lib/asciidoctor-pdf/converter.rb
+++ b/lib/asciidoctor-pdf/converter.rb
@@ -1,4 +1,4 @@
-# encoding: UTF-8
+# encoding: utf-8
 # TODO cleanup imports...decide what belongs in asciidoctor-pdf.rb
 require 'prawn'
 require_relative 'ttfunk_ext'
@@ -528,6 +528,7 @@ class Converter < ::Prawn::Document
       label_min_width = label_min_width.to_f
     end
     icons = (node.document.attr? 'icons') ? (node.document.attr 'icons') : false
+    icontype = (node.document.attr? 'icontype') ? (node.document.attr 'icontype') : 'png'
     if icons == 'font' && !(node.attr? 'icon', nil, false)
       icon_data = admonition_icon_data(label_text = type.to_sym)
       label_width = label_min_width ? label_min_width : (icon_data[:size] * 1.5)
@@ -594,19 +595,39 @@ class Converter < ::Prawn::Document
                     color: icon_data[:stroke_color],
                     size: icon_size
               elsif icons
-                begin
-                  image_obj, image_info = build_image_object icon_path
-                  icon_aspect_ratio = image_info.width.fdiv image_info.height
-                  # NOTE don't scale image up if smaller than label_width
-                  icon_width = [(to_pt image_info.width, :px), label_width].min
-                  if (icon_height = icon_width * (1 / icon_aspect_ratio)) > box_height
-                    icon_width *= box_height / icon_height
-                    icon_height = box_height
+                if icontype == 'svg'
+                  begin
+                    svg_data = ::IO.read icon_path
+                    file_request_root = ::File.dirname icon_path
+                    svg_obj = ::Prawn::Svg::Interface.new svg_data, self,
+	                                                  position: label_align,
+                                                          vposition: label_valign,
+                                                          width: label_width,
+                                                          height: box_height,
+                                                          fallback_font_name: default_svg_font,
+                                                          enable_web_requests: (node.document.attr? 'allow-uri-read'),
+                                                          enable_file_requests_with_root: file_request_root
+                    icon_width = (svg_size = svg_obj.document.sizing).output_width
+                    icon_height = svg_size.output_height
+                    svg_obj.draw
+                  rescue => e
+                    warn %(asciidoctor: WARNING: could not embed admonition icon image: #{icon_path}; #{e.message})
                   end
-                  embed_image image_obj, image_info, width: icon_width, position: label_align, vposition: label_valign
-                rescue => e
-                  # QUESTION should we show the label in this case?
-                  warn %(asciidoctor: WARNING: could not embed admonition icon image: #{icon_path}; #{e.message})
+                else
+                  begin
+                    image_obj, image_info = build_image_object icon_path
+                    icon_aspect_ratio = image_info.width.fdiv image_info.height
+                    # NOTE don't scale image up if smaller than label_width
+                    icon_width = [(to_pt image_info.width, :px), label_width].min
+                    if (icon_height = icon_width * (1 / icon_aspect_ratio)) > box_height
+                      icon_width *= box_height / icon_height
+                      icon_height = box_height
+                    end
+                    embed_image image_obj, image_info, width: icon_width, position: label_align, vposition: label_valign
+                  rescue => e
+                    # QUESTION should we show the label in this case?
+                    warn %(asciidoctor: WARNING: could not embed admonition icon image: #{icon_path}; #{e.message})
+                  end
                 end
               else
                 # IMPORTANT the label must fit in the alotted space or it shows up on another page!


### PR DESCRIPTION
This checks the 'icontype' and uses prawn-svg to render svg icons for admonitions.

Signed-off-by: Keith Packard <keithp@keithp.com>