### PR TITLE
resolves #85 place footnotes at end of chapter (book) or document (article)

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -12,6 +12,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 * upgrade prawn-svg to 0.29.1; resolves numerous SVG rendering issues (#886, #430)
 * allow running content (header and footer) to be enabled on title and toc pages; controlled by running_content_start_at property in theme (#606)
 * upgrade to FontAwesome 5; introduce the fas, far, and fab icon sets, now preferred over fa; drop support for octicons (#891) (@jessedoyle)
+* place footnotes at end of chapters in books or end of document otherwise (#85) (@bcourtine)
 * allow additional style properties to be set per heading level (#176) (@billybooth)
 * add support for hexadecimal character references (#486)
 * set line spacing for non-AsciiDoc table cells (#296)

--- a/data/themes/default-theme.yml
+++ b/data/themes/default-theme.yml
@@ -235,6 +235,9 @@ toc:
     #content: ". "
     font_color: a9a9a9
     #levels: 2 3
+footnotes:
+  font_size: round($base_font_size * 0.75)
+  item_spacing: $outline_list_item_spacing / 2
 # NOTE in addition to footer, header is also supported
 footer:
   font_size: $base_font_size_small

--- a/examples/basic-example.adoc
+++ b/examples/basic-example.adoc
@@ -12,7 +12,7 @@ A simple http://asciidoc.org[AsciiDoc] document.
 
 == Introduction
 
-A paragraph followed by a simple list with square bullets.
+A paragraph followed by an unordered list{empty}footnote:[AsciiDoc supports unordered, ordered, and description lists.] with square bullets.footnote:[You may choose from square, disc, and circle for the bullet style.]
 
 [square]
 * item 1
@@ -29,3 +29,7 @@ Prawn::Document.generate 'example.pdf' do
   text 'Hello, World!'
 end
 ----
+
+== Conclusion
+
+That's all, folks!

--- a/examples/chronicles-example.adoc
+++ b/examples/chronicles-example.adoc
@@ -48,11 +48,11 @@ image::wolpertinger.jpg[Wolpertinger,pdfwidth=50%,link={uri-wolpertinger}]
 You may not be familiar with these {uri-wolpertinger}[ravenous beasts].
 Trust us, they'll eat your shorts and suck loops from your code.
 In light of this danger, we've searched high and wide for the security crew's defensive operations manual.
-We can't find it and the DefOps{empty}footnote:[a portmanteau of “defensive” and “operations”] werewolves haven't returned from their rendezvous at Bier Central.
+We can't find it and the DefOps{empty}footnote:defops[DefOps is a portmanteau of "`defensive`" and "`operations`".] werewolves haven't returned from their rendezvous at Bier Central.
 They've either eaten each other or fallen victim to the Wolpertingers roaming the streets of ((Antwerp)).
 Quick, hit kbd:[Ctrl,Alt,Backspace] or select menu:File[Quit] and let's bail out of here!
 
-WARNING: Working with werewolves leads to howling and trying to train aggressive regular expressions with Pavlovian reinforcement.
+WARNING: Working with DefOps{empty}footnote:defops[] werewolves leads to howling and trying to train aggressive regular expressions with Pavlovian reinforcement.
 
 _Weak light from the hallway trickled across the theater, chased by a distant scream._
 
@@ -79,7 +79,7 @@ Crystalline XML tags relentlessly bombarded the theater.
 </author>
 ----
 
-Despite the assault, we were still attempting to draft an example of a defensive operation.
+Despite the assault, we continued our pursuit to draft a DefOps{empty}footnote:defops[] plan.
 
 .DefOps Plan
 ====


### PR DESCRIPTION
- place list of footnotes at end of chapter (when doctype is book) or document (when doctype is article)
- add footnotes category to theme to style footnote list
- add additional footnotes to example documents
- honor footnotes-title attribute to control title of footnote list (unset by default)