### PR TITLE
resolves #486 add support for hexadecimal character references

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -9,6 +9,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 
 * drop support for Ruby < 2.3
 * allow additional style properties to be set per heading level (#176) (@billybooth)
+* add support for hexadecimal character references (#486)
 * set line spacing for non-AsciiDoc table cells (#296)
 * consider all scripts when looking for leading alpha characters in index (#853)
 * don't create title page for article doctype unless title-page attribute is set (#105)

--- a/examples/chronicles-example.adoc
+++ b/examples/chronicles-example.adoc
@@ -60,7 +60,8 @@ _Weak light from the hallway trickled across the theater, chased by a distant sc
 
 Come on, [[bier-central,Bier Central]]_Bier Central_, of course!
 Did you have to ask?
-If you beat me there, I'll take a {uri-stbernardusabt12}[St. Bernardus Abt 12].
+If you beat me there, order me a {uri-stbernardusabt12}[St. Bernardus Abt 12].
+Here's some &#x20ac;.
 
 [#ravages]
 == The Ravages of Writing
@@ -499,7 +500,7 @@ Here's some content inside an open block.
 |Vice President
 |http://twitter.com/mojavelinux[@mojavelinux]
 
-3+^.e|Powered by Open Source
+3+^.e|Powered by Open Source(TM)
 |===
 
 [index]

--- a/lib/asciidoctor-pdf/converter.rb
+++ b/lib/asciidoctor-pdf/converter.rb
@@ -1402,7 +1402,7 @@ class Converter < ::Prawn::Document
       conum_mapping ? (restore_conums fragments, conum_mapping) : fragments
     else
       # NOTE only format if we detect a need (callouts or inline formatting)
-      if source_string =~ BuiltInEntityCharOrTagRx
+      if XmlMarkupRx.match? source_string
         text_formatter.format source_string
       else
         [{ text: source_string }]

--- a/lib/asciidoctor-pdf/core_ext/string.rb
+++ b/lib/asciidoctor-pdf/core_ext/string.rb
@@ -5,7 +5,7 @@ class String
       %(#{(Integer self) - 1})
     rescue ::ArgumentError
       # chars (upper alpha, lower alpha, lower greek)
-      ([65, 97, 945].include? ord) ? '0' : ([ord - 1].pack 'U*')
+      ([65, 97, 945].include? ord) ? '0' : ([ord - 1].pack 'U1')
     end
   end unless method_defined? :pred
 

--- a/lib/asciidoctor-pdf/formatted_text/parser.treetop
+++ b/lib/asciidoctor-pdf/formatted_text/parser.treetop
@@ -8,7 +8,7 @@ grammar Markup
   end
 
   rule complex
-    (cdata / element / entity)* {
+    (cdata / element / charref)* {
       def content
         elements.map {|e| e.content }
       end
@@ -95,24 +95,31 @@ grammar Markup
     }
   end
 
-  rule entity
-    '&' ('#' entity_number / entity_name) ';' {
+  rule charref
+    '&' ('#' character_decimal / '#x' character_hex / character_name) ';' {
       def content
-        if (entity_value = elements[1]).terminal?
-          { type: :entity, name: entity_value.text_value.to_sym }
+        if (ref_data = elements[1]).terminal?
+          { type: :charref, reference_type: :name, value: ref_data.text_value.to_sym }
+        elsif ref_data.elements[0].text_value == '#'
+          { type: :charref, reference_type: :decimal, value: ref_data.elements[1].text_value.to_i }
         else
-          { type: :entity, number: entity_value.elements[1].text_value.to_i }
+          { type: :charref, reference_type: :hex, value: ref_data.elements[1].text_value }
         end
       end
     }
   end
 
-  rule entity_number
+  rule character_decimal
     # NOTE 6 decimals only supported in Asciidoctor 1.5.5 and up
     [0-9] 2..6
   end
 
-  rule entity_name
+  rule character_hex
+    # NOTE 5 hexadecimals only supported in Asciidoctor 1.5.5 and up
+    [0-9a-f] 2..5
+  end
+
+  rule character_name
     'amp' / 'apos' / 'gt' / 'lt' / 'quot'
   end
 


### PR DESCRIPTION
- parse hexadecimal character references
- skip hexadecimal character references when transforming text to uppercase
- use abbreviate form of pack for single-character translations
- add hexadecimal character reference to chronicles example