### PR TITLE
resolves #886 upgrade prawn-svg to 0.29.1

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,6 +8,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 == Unreleased
 
 * drop support for Ruby < 2.3
+* upgrade prawn-svg to 0.29.1; resolves numerous SVG rendering issues (#886, #430)
 * allow additional style properties to be set per heading level (#176) (@billybooth)
 * set line spacing for non-AsciiDoc table cells (#296)
 * consider all scripts when looking for leading alpha characters in index (#853)

--- a/asciidoctor-pdf.gemspec
+++ b/asciidoctor-pdf.gemspec
@@ -41,8 +41,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'prawn-table', '0.2.2'
   # prawn-templates >= 0.0.5 requires prawn >= 2.2.0, so we must cast a wider net to support Ruby 1.9.3
   s.add_runtime_dependency 'prawn-templates', '>= 0.0.3', '<= 0.1.1'
-  # prawn-svg >= 0.22.1 requires Ruby >= 2.0.0, so we must cast a wider net to support Ruby 1.9.3
-  s.add_runtime_dependency 'prawn-svg', '>= 0.21.0', '< 0.28.0'
+  s.add_runtime_dependency 'prawn-svg', '~> 0.29.0'
   s.add_runtime_dependency 'prawn-icon', '1.4.0'
   s.add_runtime_dependency 'safe_yaml', '~> 1.0.0'
   s.add_runtime_dependency 'thread_safe', '~> 0.3.0'


### PR DESCRIPTION
resolves #886
resolves #430

- fixes spacing around image when only viewBox is specified
- also resolves #430 adds broader support for CSS