### PR TITLE
Add unicode support to index terms

### DIFF
--- a/lib/asciidoctor-pdf/index_catalog.rb
+++ b/lib/asciidoctor-pdf/index_catalog.rb
@@ -1,6 +1,6 @@
 module Asciidoctor; module Pdf
   class IndexCatalog
-    LeadingAlphaRx = /^\p{L}/
+    LeadingAlphaRx = /^\p{Alpha}/
 
     attr_accessor :start_page_number
 

--- a/lib/asciidoctor-pdf/index_catalog.rb
+++ b/lib/asciidoctor-pdf/index_catalog.rb
@@ -1,6 +1,6 @@
 module Asciidoctor; module Pdf
   class IndexCatalog
-    LeadingAlphaRx = /^[[:alpha:]]/u
+    LeadingAlphaRx = /^\p{L}/
 
     attr_accessor :start_page_number
 

--- a/lib/asciidoctor-pdf/index_catalog.rb
+++ b/lib/asciidoctor-pdf/index_catalog.rb
@@ -1,6 +1,6 @@
 module Asciidoctor; module Pdf
   class IndexCatalog
-    LeadingAlphaRx = /^[[:alpha:]]/
+    LeadingAlphaRx = /^[[:alpha:]]/u
 
     attr_accessor :start_page_number
 


### PR DESCRIPTION
Now index terms for non latin characters are treated as other, this makes impossible to use index for languages like cyrillic. Extending alpha regex to use unicode will fix it