### PR TITLE
resolves #490 support page layout per page

### DIFF
--- a/lib/asciidoctor-pdf/converter.rb
+++ b/lib/asciidoctor-pdf/converter.rb
@@ -1889,7 +1889,14 @@ class Converter < ::Prawn::Document
 
   # NOTE to insert sequential page breaks, you must put {nbsp} between page breaks
   def convert_page_break node
-    advance_page unless at_page_top?
+    opts = {}
+    # Detect if a page layout change was a role of the page break.
+    page_layout = resolve_layout_from_node node
+    opts = {
+              layout: (page_layout || page.layout),
+           }
+
+    advance_page opts unless at_page_top?
   end
 
   def convert_index_section node
@@ -3242,6 +3249,18 @@ class Converter < ::Prawn::Document
       align_role[5..-1].to_sym
     else
       nil
+    end
+  end
+
+  def resolve_layout_from_node node
+    if (layout = node.attributes['page-layout']).nil_or_empty? || !(PageLayouts.include?(layout = layout.to_sym))
+      if (layout = node.roles.reverse.find {|r| PageLayouts.include? r.to_sym })
+        layout.to_sym
+      else
+        nil
+      end
+    else
+      layout.to_sym
     end
   end
 


### PR DESCRIPTION
This resolves part of #490, which is the ability to use specify the page layout use a block attribute on a page break as noted in https://github.com/asciidoctor/asciidoctor-pdf/issues/490#issuecomment-237390736. 

There is extra work required in being able to set the page margins and page size as currently these are assumed to be consistent across the entire document. 

The key limitation of this PR is that the headers and footer are not resized when the layout is changed.