### PR TITLE
resolves #1033 automatically set data-uri so converter can find images generated by Asciidoctor Diagram (PR #1034)

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -20,6 +20,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 * add page layout control to page break (#490) (@resort-diaper)
 * allow additional style properties to be set per heading level (#176) (@billybooth)
 * add support for hexadecimal character references, including in link href (#486)
+* force set data-uri attribute on document so Asciidoctor Diagram returns absolute image paths (#1033)
 * set line spacing for non-AsciiDoc table cells (#296)
 * consider all scripts when looking for leading alpha characters in index (#853)
 * don't create title page for article doctype unless title-page attribute is set (#105)

--- a/README.adoc
+++ b/README.adoc
@@ -325,9 +325,10 @@ To find a complete list of available icons, consult the https://github.com/jesse
 
 == Image Paths
 
-Images are resolved relative to the value of the `imagesdir` attribute at the time the converter is run.
+Relative images paths are resolved relative to the value of the `imagesdir` attribute at the time the converter is run.
 This is effectively the same as how the built-in HTML converter works when the `data-uri` attribute is set.
-The `imagesdir` is blank by default, which means images are resolved relative to the input document.
+The `imagesdir` is blank by default, which means relative images paths are resolved relative to the input document.
+Absolute image paths are used as is.
 
 If the image is an SVG, and the SVG includes a nested raster image (PNG or JPG) with a relative path, that path is resolved relative to the directory that contains the SVG.
 
@@ -335,6 +336,18 @@ The converter will refuse to include an image if the target is a URI unless the 
 
 If the image is an SVG and that SVG links to another image, the linked image will be resolved using the same rules as the original image.
 However, note that a width and height must be specified on the linked image or else the SVG library will fail to process it.
+
+=== Asciidoctor Diagram Integration
+
+As of Asciidoctor PDF 1.5.0.alpha.17 running on Asciidoctor 2 or better, Asciidoctor PDF provides better integration with Asciidoctor Diagram by setting the `data-uri` attribute by default.
+When the `data-uri` attribute is set, Asciidoctor Diagram returns the absolute path to the generated image, which Asciidoctor PDF can then locate.
+(This makes sense since technically, Asciidoctor Diagram must embed the image in the document, similar in spirit to the `data-uri` feature for HTML).
+This means the input directory and the output directory (and thus the imagesoutdir) can differ and Asciidoctor PDF will still be able to locate the generate image.
+
+Prior to Asciidoctor PDF 1.5.0.alpha.17 (or prior to Asciidoctor 2), the way to solve this problem is to set the `imagesdir` attribute to an absolute path.
+That way, it won't matter where the generated image is written.
+Asciidoctor PDF will still be able to find it.
+Keep in mind that this strategy may introduce other side effects you'll have to work around.
 
 == Image Scaling
 

--- a/lib/asciidoctor-pdf/converter.rb
+++ b/lib/asciidoctor-pdf/converter.rb
@@ -109,6 +109,10 @@ class Converter < ::Prawn::Document
     filetype 'pdf'
     htmlsyntax 'html'
     outfilesuffix '.pdf'
+    if (doc = opts[:document])
+      # NOTE enabling data-uri forces Asciidoctor Diagram to produce absolute image paths
+      doc.attributes['data-uri'] = ((doc.instance_variable_get :@attribute_overrides) || {})['data-uri'] = ''
+    end
     @list_numbers = []
     @list_bullets = []
     @capabilities = {
@@ -147,8 +151,6 @@ class Converter < ::Prawn::Document
 
   def convert_document doc
     init_pdf doc
-    # data-uri doesn't apply to PDF, so explicitly disable (is there a better place?)
-    doc.attributes.delete 'data-uri'
     # set default value for pagenums if not otherwise set
     unless (doc.attribute_locked? 'pagenums') || ((doc.instance_variable_get :@attributes_modified).include? 'pagenums')
       doc.attributes['pagenums'] = ''
@@ -583,7 +585,10 @@ class Converter < ::Prawn::Document
     if (label_min_width = @theme.admonition_label_min_width)
       label_min_width = label_min_width.to_f
     end
-    icons = (node.document.attr? 'icons') ? (node.document.attr 'icons') : false
+    icons = ((doc = node.document).attr? 'icons') ? (doc.attr 'icons') : false
+    if (data_uri_enabled = doc.attr? 'data-uri')
+      doc.remove_attr 'data-uri'
+    end
     if icons == 'font' && !(node.attr? 'icon', nil, false)
       icon_data = admonition_icon_data(label_text = type.to_sym)
       label_width = label_min_width ? label_min_width : (icon_data[:size] * 1.5)
@@ -608,6 +613,7 @@ class Converter < ::Prawn::Document
         end
       end
     end
+    doc.set_attr 'data-uri', '' if data_uri_enabled
     unless ::Array === (cpad = @theme.admonition_padding)
       cpad = ::Array.new 4, cpad
     end
@@ -658,7 +664,7 @@ class Converter < ::Prawn::Document
                         width: label_width,
                         height: box_height,
                         fallback_font_name: default_svg_font,
-                        enable_web_requests: (node.document.attr? 'allow-uri-read'),
+                        enable_web_requests: (doc.attr? 'allow-uri-read'),
                         enable_file_requests_with_root: (::File.dirname icon_path)
                     if (icon_height = (svg_size = svg_obj.document.sizing).output_height) > box_height
                       icon_width = (svg_obj.resize height: (icon_height = box_height)).output_width

--- a/spec/converter_spec.rb
+++ b/spec/converter_spec.rb
@@ -28,15 +28,24 @@ describe Asciidoctor::Pdf::Converter do
       (expect pdf.page_count).to be > 0
     end
 
-    it 'should ignore data-uri attribute if set' do
+    it 'should ensure data-uri attribute is set' do
       doc = Asciidoctor.load <<~'EOS', backend: 'pdf', base_dir: fixtures_dir, safe: :safe
-      :data-uri:
+      image::logo.png[]
+      EOS
+      (expect doc.attr? 'data-uri').to be true
+      doc.convert
+      (expect doc.attr? 'data-uri').to be true
+    end
+
+    it 'should ignore data-uri attribute entry in document' do
+      doc = Asciidoctor.load <<~'EOS', backend: 'pdf', base_dir: fixtures_dir, safe: :safe
+      :!data-uri:
 
       image::logo.png[]
       EOS
-      (expect doc.attr? 'data-uri', '').to be true
+      (expect doc.attr? 'data-uri').to be true
       doc.convert
-      (expect doc.attr? 'data-uri').to be false
+      (expect doc.attr? 'data-uri').to be true
     end
 
     it 'should use theme passed in through :pdf_theme option' do


### PR DESCRIPTION
- when data-uri is set, Asciidoctor Diagram returns absolute image paths
- this allow the input and output directory to differ while still allowing Asciidoctor PDF to locate generated images