### PR TITLE
resolves #1181 restore media=prepress behavior

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -14,6 +14,8 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 * set fallback value for base (root) font size
 * always resolve images in running content relative to themesdir (instead of document) (#1183)
 * honor text alignment role on abstract paragraph(s)
+* don't insert blank page at start of document if media=prepress and document does not have a cover (#1181)
+* insert blank page after cover if media=prepress (#1181)
 
 == 1.5.0.beta.2 (2019-07-30) - @mojavelinux
 

--- a/lib/asciidoctor-pdf/converter.rb
+++ b/lib/asciidoctor-pdf/converter.rb
@@ -222,9 +222,7 @@ class Converter < ::Prawn::Document
       end
     end
 
-    # FIXME only apply to book doctype once title and toc are moved to start page when using article doctype
-    #start_new_page if @ppbook && verso_page?
-    start_new_page if @media == 'prepress' && verso_page?
+    start_new_page if @ppbook && verso_page?
 
     if insert_title_page
       body_offset = (body_start_page_number = page_number) - 1
@@ -313,7 +311,7 @@ class Converter < ::Prawn::Document
       # NOTE prepare scratch document to use page margin from recto side (which has same width as verso side)
       set_page_margin page_margin_recto unless page_margin_recto == page_margin
     else
-      @ppbook = false
+      @ppbook = nil
     end
     # QUESTION should ThemeLoader handle registering fonts instead?
     register_fonts theme.font_catalog, (doc.attr 'scripts', 'latin'), (doc.attr 'pdf-fontsdir', ThemeLoader::FontsDir)
@@ -2423,8 +2421,8 @@ class Converter < ::Prawn::Document
 
     # NOTE a new page may have already been started at this point, so decide what to do with it
     if page.empty?
-      page.reset_content if (recycle = @ppbook ? verso_page? : true)
-    elsif @ppbook && verso_page?
+      page.reset_content if (recycle = @ppbook ? recto_page? : true)
+    elsif @ppbook && page_number > 0 && recto_page?
       start_new_page
     end
 

--- a/spec/media_spec.rb
+++ b/spec/media_spec.rb
@@ -1,0 +1,112 @@
+require_relative 'spec_helper'
+
+describe 'Asciidoctor::PDF::Converter - media' do
+  context 'prepress' do
+    it 'should leave blank page after image cover page' do
+      pdf = to_pdf <<~EOS
+      = Document Title
+      :doctype: book
+      :media: prepress
+      :front-cover-image: #{fixture_file 'cover.jpg', relative: true}
+
+      == Chapter Title
+      EOS
+
+      (expect pdf.pages).to have_size 5
+      (expect (pdf.page 3).text).to eql 'Document Title'
+      (expect (pdf.page 5).text).to eql 'Chapter Title'
+      images = get_images pdf, 1
+      (expect images).to have_size 1
+      (expect images[0].data).to eql File.binread fixture_file 'cover.jpg'
+    end
+
+    it 'should leave blank page after PDF cover page' do
+      pdf = to_pdf <<~EOS
+      = Document Title
+      :doctype: book
+      :media: prepress
+      :front-cover-image: #{fixture_file 'blue-letter.pdf', relative: true}
+
+      == Chapter Title
+      EOS
+
+      (expect pdf.pages).to have_size 5
+      (expect (pdf.page 1).text).to be_empty
+      (expect (pdf.page 3).text).to eql 'Document Title'
+      (expect (pdf.page 5).text).to eql 'Chapter Title'
+      # TODO add helper method to get content stream for page
+      title_page_contents = pdf.objects[(pdf.page 1).page_object[:Contents][0]].data
+      (expect (title_page_contents.split ?\n).slice 0, 3).to eql ['q', '/DeviceRGB cs', '0.0 0.0 1.0 scn']
+    end
+
+    it 'should insert blank page after TOC' do
+      pdf = to_pdf <<~EOS, analyze: true
+      = Document Title
+      :doctype: book
+      :media: prepress
+      :toc:
+      :front-cover-image: #{fixture_file 'cover.jpg', relative: true}
+
+      == Beginning
+
+      == Middle
+
+      == End
+      EOS
+
+      (expect pdf.pages).to have_size 11
+      (expect (pdf.find_text 'Document Title')[0][:page_number]).to eql 3
+      (expect (pdf.find_text 'Table of Contents')[0][:page_number]).to eql 5
+      (expect (pdf.find_text 'Beginning')[0][:page_number]).to eql 5
+      (expect (pdf.find_text 'Beginning')[1][:page_number]).to eql 7
+      (expect (pdf.find_text 'Middle')[0][:page_number]).to eql 5
+      (expect (pdf.find_text 'Middle')[1][:page_number]).to eql 9
+      (expect (pdf.find_text 'End')[0][:page_number]).to eql 5
+      (expect (pdf.find_text 'End')[1][:page_number]).to eql 11
+    end
+
+    it 'should not insert blank page at start of document if document has no cover' do
+      pdf = to_pdf <<~'EOS', analyze: true
+      = Document Title
+      :doctype: book
+      :media: prepress
+
+      Preface content.
+
+      == Chapter Title
+
+      Chapter content.
+      EOS
+
+      (expect pdf.pages).to have_size 5
+      doctitle_text = (pdf.find_text 'Document Title')[0]
+      (expect doctitle_text[:page_number]).to eql 1
+      preface_text = (pdf.find_text 'Preface content.')[0]
+      (expect preface_text[:page_number]).to eql 3
+      chapter_title_text = (pdf.find_text 'Chapter Title')[0]
+      (expect chapter_title_text[:page_number]).to eql 5
+    end
+
+    it 'should not insert blank page at start of document with toc if title page is disabled' do
+      pdf = to_pdf <<~'EOS', analyze: true
+      = Document Title
+      :doctype: book
+      :media: prepress
+      :notitle:
+      :toc:
+
+      == Chapter Title
+
+      Chapter content.
+      EOS
+
+      (expect pdf.pages).to have_size 3
+      toc_text = (pdf.find_text 'Table of Contents')[0]
+      (expect toc_text[:page_number]).to eql 1
+      chapter_title_texts = pdf.find_text 'Chapter Title'
+      (expect chapter_title_texts).to have_size 2
+      (expect chapter_title_texts[0][:page_number]).to eql 1
+      (expect chapter_title_texts[1][:page_number]).to eql 3
+    end
+  end
+end


### PR DESCRIPTION
* don't insert blank page at start of document if media=prepress and document does not have a cover
* insert blank page after cover if media=prepress