### PR TITLE
resolves #80 allow multiple font dirs to be specified

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,6 +8,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 == Unreleased
 
 * allow page background color and background image to be used simultaneously (#1186)
+* allow multiple font dirs to be specified (#80)
 * allow theme to specifiy initial zoom (#305)
 * add the .notdef glyph to the bundled fonts (a box which is used as the default glyph if the font is missing a character) (#1194)
 * don't drop headings if base font family is not set in theme

--- a/docs/theming-guide.adoc
+++ b/docs/theming-guide.adoc
@@ -733,8 +733,8 @@ A sans-serif font that provides a very complete set of Unicode glyphs.
 Cannot be styled as italic, bold or bold_italic.
 Used as the fallback font in the `default-with-fallback-font` theme.
 
-CAUTION: At the time of this writing, you cannot use the bundled fonts if you change the value of the `pdf-fontsdir` attribute (and thus define your own custom fonts).
-This limitation may be lifted in the future.
+TIP: If you want to specify the location of custom fonts using the `pdf-fontsdir` attribute, yet still be able to use the bundled fonts, you need to refer to the bundled fonts using the `GEM_FONTS_DIR` token.
+To do so, you can either a) prefix the path of the bundled font in the theme file with the segment `GEM_FONTS_DIR` (e.g., `GEM_FONTS_DIR/mplus1p-regular-fallback.ttf`, or b) include `GEM_FONT_DIR` in the value of the `pdf-fontsdir` attribute, separated from the location of your custom fonts by the path separator (e.g., `path/to/fonts:GEM_FONTS_DIR`).
 
 === Custom Fonts
 
@@ -792,7 +792,13 @@ When you execute Asciidoctor PDF, specify the directory where the fonts reside u
 
  $ asciidoctor-pdf -a pdf-theme=basic-theme.yml -a pdf-fontsdir=path/to/fonts document.adoc
 
-WARNING: Currently, all fonts referenced by the theme need to be present in the directory specified by the `pdf-fontsdir` attribute.
+You can specify multiple directories by separating the entries with the path separator (`:` for Unix, `;` for Windows).
+
+ $ asciidoctor-pdf -a pdf-theme=basic-theme.yml -a pdf-fontsdir=path/to/fonts:path/to/more-fonts document.adoc
+
+To include the bundled fonts in the search, use the `GEM_FONTS_DIR` token:
+
+ $ asciidoctor-pdf -a pdf-theme=basic-theme.yml -a pdf-fontsdir=path/to/fonts:GEM_FONTS_DIR document.adoc
 
 TIP: When Asciidoctor PDF creates the PDF, it only embeds the glyphs from the font that are needed to render the characters present in the document.
 Effectively, it subsets the font.
@@ -3992,7 +3998,8 @@ _Specifying an absolute path is recommended._
 If you use images in your theme, image paths are resolved relative to this directory.
 If `pdf-theme` ends with `.yml`, and `pdf-themesdir` is not specified, then `pdf-themesdir` defaults to the directory of the path specified by `pdf-theme`.
 
-pdf-fontsdir:: The directory where the fonts used by your theme, if any, are located.
+pdf-fontsdir:: The directory or directories where the fonts used by your theme, if any, are located.
+Multiple entries must be separated by path separator (`:` for Unix, `;` for Windows).
 _Specifying an absolute path is recommended._
 
 Let's assume that you've put your theme files inside a directory named `resources` with the following layout:
@@ -4015,7 +4022,7 @@ Here's how you'd load your theme when calling Asciidoctor PDF:
 
 If all goes well, Asciidoctor PDF should run without an error or warning.
 
-NOTE: You only need to specify the `pdf-fontsdir` if you are using custom fonts in your theme.
+NOTE: You only need to specify the `pdf-fontsdir` if you're using custom fonts in your theme.
 
 You can skip setting the `pdf-themesdir` attribute and just pass the absolute path of your theme file to the `pdf-theme` attribute.
 

--- a/lib/asciidoctor-pdf/theme_loader.rb
+++ b/lib/asciidoctor-pdf/theme_loader.rb
@@ -124,7 +124,17 @@ class ThemeLoader
       val.each do |subkey, subval|
         if subkey == 'catalog' && ::Hash === subval
           subval = subval.reduce({}) do |accum, (name, styles)|
-            accum[name] = ::Hash === styles ? styles.reduce({}) {|subaccum, (style, path)| subaccum[style] = (expand_vars path, data); subaccum } : styles
+            if ::Hash === styles
+              accum[name] = styles.reduce({}) do |subaccum, (style, path)|
+                if (path.start_with? 'GEM_FONTS_DIR') && (sep = path[13])
+                  path = %(#{FontsDir}#{sep}#{path.slice 14, path.length})
+                end
+                subaccum[style] = expand_vars path, data
+                subaccum
+              end
+            else
+              accum[name] = styles
+            end
             accum
           end
         end

--- a/spec/fixtures/bundled-fonts-theme.yml
+++ b/spec/fixtures/bundled-fonts-theme.yml
@@ -1,0 +1,8 @@
+extends: default
+font:
+  catalog:
+    Noto Serif:
+      normal: GEM_FONTS_DIR/notoserif-regular-subset.ttf
+      bold: GEM_FONTS_DIR/notoserif-bold-subset.ttf
+      italic: GEM_FONTS_DIR/notoserif-italic-subset.ttf
+      bold_italic: GEM_FONTS_DIR/notoserif-bold_italic-subset.ttf

--- a/spec/font_spec.rb
+++ b/spec/font_spec.rb
@@ -70,6 +70,36 @@ describe 'Asciidoctor::PDF::Converter - Font' do
     end
   end
 
+  context 'custom' do
+    it 'should resolve fonts in specified fonts dir' do
+      pdf = to_pdf 'content', attribute_overrides: { 'pdf-fontsdir' => Asciidoctor::Pdf::ThemeLoader::FontsDir }
+      fonts = pdf.objects.values.select {|it| ::Hash === it && it[:Type] == :Font }
+      (expect fonts).to have_size 1
+      (expect fonts[0][:BaseFont]).to end_with '+NotoSerif'
+    end
+
+    it 'should look for font file in all specified font dirs' do
+      pdf = to_pdf 'content', attribute_overrides: { 'pdf-fontsdir' => ([fixtures_dir, Asciidoctor::Pdf::ThemeLoader::FontsDir].join File::PATH_SEPARATOR) }
+      fonts = pdf.objects.values.select {|it| ::Hash === it && it[:Type] == :Font }
+      (expect fonts).to have_size 1
+      (expect fonts[0][:BaseFont]).to end_with '+NotoSerif'
+    end
+
+    it 'should look for font file in gem fonts dir if path entry is empty' do
+      pdf = to_pdf 'content', attribute_overrides: { 'pdf-fontsdir' => ([fixtures_dir, ''].join File::PATH_SEPARATOR) }
+      fonts = pdf.objects.values.select {|it| ::Hash === it && it[:Type] == :Font }
+      (expect fonts).to have_size 1
+      (expect fonts[0][:BaseFont]).to end_with '+NotoSerif'
+    end
+
+    it 'should expand GEM_FONTS_DIR in theme file' do
+      pdf = to_pdf 'content', attribute_overrides: { 'pdf-theme' => (fixture_file 'bundled-fonts-theme.yml'), 'pdf-fontsdir' => fixtures_dir }
+      fonts = pdf.objects.values.select {|it| ::Hash === it && it[:Type] == :Font }
+      (expect fonts).to have_size 1
+      (expect fonts[0][:BaseFont]).to end_with '+NotoSerif'
+    end
+  end
+
   context 'Kerning' do
     it 'should enable kerning when using default theme' do
       to_file = to_pdf_file <<~'EOS', 'font-kerning-default.pdf'


### PR DESCRIPTION
- pdf-fontsdir accepts multiple directories, separated by the path separator
- font dirs are searched until the requested font is found
- allow gem fonts dir to be referenced in font catalog of theme using GEM_FONTS_DIR token
- document support for multiple font directories, including the GEM_FONTS_DIR token, in the theming guide