### PR TITLE
resolves #1210 allow theme to control min height required after section

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -17,6 +17,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 * don't rely on base_line_height_length theme key in converter (should be internal to theme)
 * set fallback value for base (root) font size
 * reduce min font size in base theme
+* allow theme to configure the minimum height required after a section title for it to stay on same page (#1210)
 * convert hyphen to underscore in theme key for admonition icon type (#1217)
 * always resolve images in running content relative to themesdir (instead of document) (#1183)
 * honor text alignment role on abstract paragraph(s)

--- a/data/themes/base-theme.yml
+++ b/data/themes/base-theme.yml
@@ -40,6 +40,7 @@ heading_h6_font_size: 10
 heading_line_height: 1.15
 heading_margin_top: 4
 heading_margin_bottom: 12
+heading_min_height_after: 20
 title_page_align: center
 title_page_line_height: 1.15
 title_page_logo_top: 10%

--- a/data/themes/default-theme.yml
+++ b/data/themes/default-theme.yml
@@ -102,6 +102,7 @@ heading:
   line_height: 1
   margin_top: $vertical_rhythm * 0.4
   margin_bottom: $vertical_rhythm * 0.9
+  min_height_after: $base_line_height_length * 1.5
 title_page:
   align: right
   logo:

--- a/docs/theming-guide.adoc
+++ b/docs/theming-guide.adoc
@@ -1425,6 +1425,12 @@ The keys in this category control the style of most headings, including part tit
 |heading:
   margin-bottom: 9.6
 
+|min-height-after
+|<<measurement-units,Measurement>> +
+(default: $base-font-size * $base-line-height * 1.5)
+|heading:
+  min-height-after: 0.5in
+
 |chapter-break-before
 |always {vbar} auto +
 (default: always)

--- a/lib/asciidoctor-pdf/converter.rb
+++ b/lib/asciidoctor-pdf/converter.rb
@@ -530,10 +530,15 @@ class Converter < ::Prawn::Document
           start_new_part sect unless @theme.heading_part_break_before == 'auto'
         end
       end
-      # FIXME smarter calculation here!!
-      unless cursor > (height_of title) + (@theme.heading_margin_top || 0) + (@theme.heading_margin_bottom || 0) + (@root_font_size * @theme.base_line_height * 1.5)
-        start_new_page
-      end unless at_page_top?
+      unless at_page_top?
+        # FIXME this height doesn't account for impact of text transform or inline formatting
+        heading_height =
+          (height_of_typeset_text title, line_height: (@theme[%(heading_h#{hlevel}_line_height)] || @theme.heading_line_height)) +
+          (@theme[%(heading_h#{hlevel}_margin_top)] || @theme.heading_margin_top || 0) +
+          (@theme[%(heading_h#{hlevel}_margin_bottom)] || @theme.heading_margin_bottom || 0)
+        heading_height += (@theme.heading_min_height_after || 0) if sect.blocks?
+        start_new_page unless cursor > heading_height
+      end
       # QUESTION should we store pdf-page-start, pdf-anchor & pdf-destination in internal map?
       sect.set_attr 'pdf-page-start', (start_pgnum = page_number)
       # QUESTION should we just assign the section this generated id?


### PR DESCRIPTION
- allow theme to control min height required after section to keep on same page
- don't shift section to next page if requirement isn't met and section is empty