### PR TITLE
resolves #1250 always use ; as delimiter to separate multiple font dirs

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -7,6 +7,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 
 == Unreleased
 
+* always use ; as delimiter to separate multiple font dirs to be compatible with JAR paths (#1250)
 * allow font catalog and font fallbacks to be defined as flat keys in the theme file (#1243)
 * don't crash when adding indentation guards to source highlighted with Pygments (#1246)
 * don't override font color of formatted text in toc (#1247)

--- a/docs/theming-guide.adoc
+++ b/docs/theming-guide.adoc
@@ -734,7 +734,7 @@ Cannot be styled as italic, bold or bold_italic.
 Used as the fallback font in the `default-with-fallback-font` theme.
 
 TIP: If you want to specify the location of custom fonts using the `pdf-fontsdir` attribute, yet still be able to use the bundled fonts, you need to refer to the bundled fonts using the `GEM_FONTS_DIR` token.
-To do so, you can either a) prefix the path of the bundled font in the theme file with the segment `GEM_FONTS_DIR` (e.g., `GEM_FONTS_DIR/mplus1p-regular-fallback.ttf`, or b) include `GEM_FONT_DIR` in the value of the `pdf-fontsdir` attribute, separated from the location of your custom fonts by the path separator (e.g., `path/to/fonts:GEM_FONTS_DIR`).
+To do so, you can either a) prefix the path of the bundled font in the theme file with the segment `GEM_FONTS_DIR` (e.g., `GEM_FONTS_DIR/mplus1p-regular-fallback.ttf`, or b) include `GEM_FONT_DIR` in the value of the `pdf-fontsdir` attribute, separated from the location of your custom fonts by a semi-colon (e.g., `path/to/your/fonts;GEM_FONTS_DIR`).
 
 === Custom Fonts
 
@@ -792,13 +792,13 @@ When you execute Asciidoctor PDF, specify the directory where the fonts reside u
 
  $ asciidoctor-pdf -a pdf-theme=basic-theme.yml -a pdf-fontsdir=path/to/fonts document.adoc
 
-You can specify multiple directories by separating the entries with the path separator (`:` for Unix, `;` for Windows).
+You can specify multiple directories by separating the entries with a semi-colon:
 
- $ asciidoctor-pdf -a pdf-theme=basic-theme.yml -a pdf-fontsdir=path/to/fonts:path/to/more-fonts document.adoc
+ $ asciidoctor-pdf -a pdf-theme=basic-theme.yml -a pdf-fontsdir=path/to/fonts;path/to/more-fonts document.adoc
 
 To include the bundled fonts in the search, use the `GEM_FONTS_DIR` token:
 
- $ asciidoctor-pdf -a pdf-theme=basic-theme.yml -a pdf-fontsdir=path/to/fonts:GEM_FONTS_DIR document.adoc
+ $ asciidoctor-pdf -a pdf-theme=basic-theme.yml -a pdf-fontsdir=path/to/fonts;GEM_FONTS_DIR document.adoc
 
 TIP: When Asciidoctor PDF creates the PDF, it only embeds the glyphs from the font that are needed to render the characters present in the document.
 Effectively, it subsets the font.
@@ -4077,7 +4077,7 @@ If you use images in your theme, image paths are resolved relative to this direc
 If `pdf-theme` ends with `.yml`, and `pdf-themesdir` is not specified, then `pdf-themesdir` defaults to the directory of the path specified by `pdf-theme`.
 
 pdf-fontsdir:: The directory or directories where the fonts used by your theme, if any, are located.
-Multiple entries must be separated by path separator (`:` for Unix, `;` for Windows).
+Multiple entries must be separated by a semi-colon.
 _Specifying an absolute path is recommended._
 
 Let's assume that you've put your theme files inside a directory named `resources` with the following layout:

--- a/lib/asciidoctor-pdf/converter.rb
+++ b/lib/asciidoctor-pdf/converter.rb
@@ -324,7 +324,7 @@ class Converter < ::Prawn::Document
       @ppbook = nil
     end
     # QUESTION should ThemeLoader handle registering fonts instead?
-    register_fonts theme.font_catalog, (doc.attr 'pdf-fontsdir', ThemeLoader::FontsDir)
+    register_fonts theme.font_catalog, (doc.attr 'pdf-fontsdir', 'GEM_FONTS_DIR')
     default_kerning theme.base_font_kerning != 'none'
     @fallback_fonts = [*theme.font_fallbacks]
     @allow_uri_read = doc.attr? 'allow-uri-read'
@@ -3318,8 +3318,8 @@ class Converter < ::Prawn::Document
 
   def register_fonts font_catalog, fonts_dir
     return unless font_catalog
-    dirs = (fonts_dir.split ::File::PATH_SEPARATOR, -1).map do |dir|
-      dir.empty? || dir == 'GEM_FONTS_DIR' ? ThemeLoader::FontsDir : dir
+    dirs = (fonts_dir.split ';', -1).map do |dir|
+      dir == 'GEM_FONTS_DIR' || dir.empty? ? ThemeLoader::FontsDir : dir
     end
     font_catalog.each do |key, styles|
       styles = styles.reduce({}) do |accum, (style, path)|

--- a/spec/font_spec.rb
+++ b/spec/font_spec.rb
@@ -79,14 +79,21 @@ describe 'Asciidoctor::PDF::Converter - Font' do
     end
 
     it 'should look for font file in all specified font dirs' do
-      pdf = to_pdf 'content', attribute_overrides: { 'pdf-fontsdir' => ([fixtures_dir, Asciidoctor::Pdf::ThemeLoader::FontsDir].join File::PATH_SEPARATOR) }
+      pdf = to_pdf 'content', attribute_overrides: { 'pdf-fontsdir' => ([fixtures_dir, Asciidoctor::Pdf::ThemeLoader::FontsDir].join ';') }
       fonts = pdf.objects.values.select {|it| ::Hash === it && it[:Type] == :Font }
       (expect fonts).to have_size 1
       (expect fonts[0][:BaseFont]).to end_with '+NotoSerif'
     end
 
     it 'should look for font file in gem fonts dir if path entry is empty' do
-      pdf = to_pdf 'content', attribute_overrides: { 'pdf-fontsdir' => ([fixtures_dir, ''].join File::PATH_SEPARATOR) }
+      pdf = to_pdf 'content', attribute_overrides: { 'pdf-fontsdir' => ([fixtures_dir, ''].join ';') }
+      fonts = pdf.objects.values.select {|it| ::Hash === it && it[:Type] == :Font }
+      (expect fonts).to have_size 1
+      (expect fonts[0][:BaseFont]).to end_with '+NotoSerif'
+    end
+
+    it 'should look for font file in gem fonts dir if path entry is GEM_FONTS_DIR' do
+      pdf = to_pdf 'content', attribute_overrides: { 'pdf-fontsdir' => ([fixtures_dir, 'GEM_FONTS_DIR'].join ';') }
       fonts = pdf.objects.values.select {|it| ::Hash === it && it[:Type] == :Font }
       (expect fonts).to have_size 1
       (expect fonts[0][:BaseFont]).to end_with '+NotoSerif'


### PR DESCRIPTION
- to be compatible with JAR paths