### PR TITLE
resolves #1320 set default footer content in base theme

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -5,6 +5,10 @@
 This document provides a high-level view of the changes to the {project-name} by release.
 For a detailed view of what has changed, refer to the {uri-repo}/commits/master[commit history] on GitHub.
 
+== Unreleased
+
+* set default footer content in base theme; remove logic to process `footer_<side>_content: none` key (#1320)
+
 == 1.5.0.beta.6 (2019-10-11) - @mojavelinux
 
 * reorganize source files under asciidoctor/pdf folder (instead of asciidoctor-pdf)

--- a/data/themes/base-theme.yml
+++ b/data/themes/base-theme.yml
@@ -114,3 +114,5 @@ toc_indent: 15
 toc_line_height: 1.4
 footnotes_font_size: 9
 footnotes_item_space: 3
+footer_recto_right_content: '{page-number}'
+footer_verso_left_content: '{page-number}'

--- a/docs/theming-guide.adoc
+++ b/docs/theming-guide.adoc
@@ -4226,9 +4226,6 @@ IMPORTANT: If you don't specify a height for either the header or footer key, it
 
 If you define running header and footer content in your theme (including the height), you can still disable this content per document by setting the `noheader` and `nofooter` attributes in the AsciiDoc document header, respectively.
 
-If content is not specified for the running footer, the page number (i.e., `\{page-number}`) is shown on the left on verso pages and the right on recto pages.
-You can disable this behavior by defining the attribute `nofooter` in the AsciiDoc document header or by defining the key `footer-<side>-content: none` in the theme.
-
 TIP: Although not listed in the table above, you can control the font settings (font-family, font-size, font-color, font-style, text-transform) that get applied to the running content in each column position for each page side (e.g., `footer-<side>-<position>-font-color`).
 For example, you can set the font color used for the right-hand column on recto pages by setting `footer-recto-right-font-color: 6CC644`.
 

--- a/lib/asciidoctor/pdf/converter.rb
+++ b/lib/asciidoctor/pdf/converter.rb
@@ -3245,8 +3245,7 @@ class Converter < ::Prawn::Document
   end
 
   def allocate_running_content_layout page, periphery, cache
-    layout = page.layout
-    cache[layout] ||= begin
+    cache[layout = page.layout] ||= begin
       trim_styles = {
         line_metrics: (trim_line_metrics = calc_line_metrics @theme[%(#{periphery}_line_height)] || @theme.base_line_height),
         # NOTE we've already verified this property is set
@@ -3348,10 +3347,6 @@ class Converter < ::Prawn::Document
               side_content[position] = val
             end
           end
-        end
-        # NOTE set fallbacks if not explicitly disabled
-        if side_content.empty? && periphery == :footer && @theme[%(footer_#{side}_content)] != 'none'
-          side_content = { side == :recto ? :right : :left => '{page-number}' }
         end
 
         acc[side] = side_content

--- a/spec/running_content_spec.rb
+++ b/spec/running_content_spec.rb
@@ -95,6 +95,29 @@ describe 'Asciidoctor::PDF::Converter - Running Content' do
 
       (expect pdf.find_text %r/^\d+$/).to be_empty
     end
+
+	  it 'should add footer if theme extends base and footer height is set' do
+			pdf_theme = {
+				extends: 'base',
+				footer_height: 36,
+			}
+			pdf = to_pdf <<~'EOS', attribute_overrides: { 'nofooter' => nil }, pdf_theme: pdf_theme, analyze: true
+			= Document Title
+			:doctype: book
+
+			== Beginning
+
+			== End
+			EOS
+
+			pagenum_1_text = (pdf.find_text '1')[0]
+			pagenum_2_text = (pdf.find_text '2')[0]
+			(expect pagenum_1_text).not_to be_nil
+			(expect pagenum_1_text[:page_number]).to eql 2
+			(expect pagenum_2_text).not_to be_nil
+			(expect pagenum_2_text[:page_number]).to eql 3
+			(expect pagenum_1_text[:x]).to be > pagenum_2_text[:x]
+		end
   end
 
   context 'Header' do


### PR DESCRIPTION
- remove logic to process `footer_<side>_content: none` key