### PR TITLE
Bump treetop to 1.6

### DIFF
--- a/asciidoctor-pdf.gemspec
+++ b/asciidoctor-pdf.gemspec
@@ -45,8 +45,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'safe_yaml', '~> 1.0.0'
   s.add_runtime_dependency 'thread_safe', '~> 0.3.0'
   s.add_runtime_dependency 'concurrent-ruby', '~> 1.1.0'
-  # For our usage, treetop 1.6 is slower than treetop 1.5
-  s.add_runtime_dependency 'treetop', '~> 1.5.0'
+  s.add_runtime_dependency 'treetop', '~> 1.6.0'
 
   s.add_development_dependency 'rake', '~> 13.0.0'
   s.add_development_dependency 'rspec', '~> 3.9.0'


### PR DESCRIPTION
Treetop 1.5 is now five years old and some distributions have been
running with treetop 1.6 without issue for some time.