### PR TITLE
resolves #1348 don't duplicate first section in outline if doctitle is not set

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -9,6 +9,8 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 
 * fix value of implicit page-count attribute when page numbering and running content don't start on same page (#1334)
 * fix value of implicit chapter-title attribute on preface pages (#1340)
+* show value of untitled-label attribute in outline if doctitle is not set (#1348)
+* don't show entry for doctitle in outline if doctitle is not set and untitled-label attribute is unset (#1348)
 * allow elements on title page to be disabled from theme using display: none (#1346)
 * set chapter-title attribute to value of toc-title attribute on toc pages in book (#1338)
 * set section-title attribute to value of toc-title attribute on toc pages in article if page has no other sections (#1338)

--- a/lib/asciidoctor/pdf/converter.rb
+++ b/lib/asciidoctor/pdf/converter.rb
@@ -463,7 +463,7 @@ class Converter < ::Prawn::Document
   def build_pdf_info doc
     info = {}
     # FIXME use sanitize: :plain_text once available
-    if (doctitle = doc.doctitle use_fallback: true)
+    if (doctitle = doc.header? ? doc.doctitle : (doc.attr 'untitled-label'))
       info[:Title] = (sanitize doctitle).as_pdf
     end
     info[:Author] = (doc.attr 'authors').as_pdf if doc.attr? 'authors'
@@ -3452,7 +3452,7 @@ class Converter < ::Prawn::Document
       initial_pagenum = has_front_cover ? 2 : 1
       initial_pagenum -= 1 unless doc.doctype == 'book' || (doc.attr? 'title-page')
       # FIXME use sanitize: :plain_text once available
-      if document.page_count > initial_pagenum && (doctitle = doc.doctitle use_fallback: true)
+      if document.page_count > initial_pagenum && (doctitle = doc.header? ? doc.doctitle : (doc.attr 'untitled-label'))
         page title: (document.sanitize doctitle), destination: (document.dest_top has_front_cover ? 2 : 1)
       end
       unless toc_page_nums.none? || (toc_title = doc.attr 'toc-title').nil_or_empty?

--- a/spec/outline_spec.rb
+++ b/spec/outline_spec.rb
@@ -363,7 +363,44 @@ describe 'Asciidoctor::PDF::Converter - Outline' do
     (expect get_page_labels pdf).to eql %w(1 2)
   end
 
-  it 'should not crash if doctitle is not set and untitled-label attribute is unset' do
+  it 'should set doctitle in outline to value of untitled-label attribute if document has no doctitle or sections' do
+    pdf = to_pdf 'body only'
+
+    outline = extract_outline pdf
+    (expect outline).to have_size 1
+    (expect outline[0][:title]).to eql 'Untitled'
+    (expect outline[0][:children]).to be_empty
+  end
+
+  it 'should set doctitle in outline to value of untitled-label attribute if document has no doctitle and has sections' do
+    pdf = to_pdf <<~'EOS'
+    == First Section
+
+    == Last Section
+    EOS
+
+    outline = extract_outline pdf
+    (expect outline).to have_size 3
+    (expect outline[0][:title]).to eql 'Untitled'
+    (expect outline[0][:children]).to be_empty
+  end
+
+  it 'should set not set doctitle in outline if document has no doctitle, has sections, and untitled-label attribute is unset' do
+    pdf = to_pdf <<~'EOS'
+    :untitled-label!:
+
+    == First Section
+
+    == Last Section
+    EOS
+
+    outline = extract_outline pdf
+    (expect outline).to have_size 2
+    (expect outline[0][:title]).to eql 'First Section'
+    (expect outline[1][:title]).to eql 'Last Section'
+  end
+
+  it 'should not crash if doctitle is not set and untitled-label attribute is unset and document has no sections' do
     pdf = to_pdf <<~'EOS'
     :untitled-label!:
 

--- a/spec/pdf_info_spec.rb
+++ b/spec/pdf_info_spec.rb
@@ -111,6 +111,11 @@ describe 'Asciidoctor::PDF::Converter - PDF Info' do
       (expect pdf.info[:Title]).to eql 'Untitled'
     end
 
+    it 'should not set Title field if untitled-label attribute is unset and doctitle is not set' do
+      pdf = to_pdf 'body', attribute_overrides: { 'untitled-label' => nil }
+      (expect pdf.info).not_to have_key :Title
+    end
+
     it 'should set Title field to value of document title if set' do
       pdf = to_pdf '= Document Title'
       (expect pdf.info[:Title]).to eql 'Document Title'


### PR DESCRIPTION
* show value of untitled-label attribute in outline if doctitle is not set
* don't show entry for doctitle in outline if doctitle is not set and untitled-label attribute is unset