### PR TITLE
resolves #1359 break CJK characters in table when scripts attribute is `cjk`

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,6 +8,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 == Unreleased
 
 * allow theme to override styles of caption on admonition blocks (#561)
+* if value of scripts attribute is cjk, break lines between any two CJK characters except punctuation in table cells (#1359) (*gasol*)
 
 == 1.5.0.beta.7 (2019-10-29) - @mojavelinux
 

--- a/lib/asciidoctor/pdf/converter.rb
+++ b/lib/asciidoctor/pdf/converter.rb
@@ -2061,6 +2061,7 @@ class Converter < ::Prawn::Document
         unless cell_data.key? :content
           cell_text = cell.text.strip
           cell_text = transform_text cell_text if cell_transform
+          cell_text = cell_text.gsub CjkLineBreakRx, ZeroWidthSpace if @cjk_line_breaks
           if cell_text.include? LF
             # NOTE effectively the same as calling cell.content (should we use that instead?)
             # FIXME hard breaks not quite the same result as separate paragraphs; need custom cell impl here

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ end
 require 'asciidoctor/pdf'
 require 'base64'
 require 'chunky_png'
+require 'fileutils'
 require 'open3' unless defined? Open3
 require 'pathname' unless defined? Pathname
 require 'pdf/inspector'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,6 @@ end
 require 'asciidoctor/pdf'
 require 'base64'
 require 'chunky_png'
-require 'fileutils'
 require 'open3' unless defined? Open3
 require 'pathname' unless defined? Pathname
 require 'pdf/inspector'

--- a/spec/table_spec.rb
+++ b/spec/table_spec.rb
@@ -895,5 +895,23 @@ describe 'Asciidoctor::PDF::Converter - Table' do
       (expect second_a1_text[:x]).to be > (page_width * 0.5)
       (expect first_a1_text[:x]).to be > second_a1_text[:x]
     end
+
+    it 'should break line on any CJK character if value of scripts attribute is cjk' do
+      pdf = to_pdf <<~'EOS', analyze: true
+      :scripts: cjk
+      :pdf-theme: default-with-fallback-font
+
+      |===
+      | AsciiDoc 是一个人类可读的文件格式，语义上等同于 DocBook 的 XML，但使用纯文本标记了约定。可以使用任何文本编辑器创建文件把 AsciiDoc 和阅读“原样”，或呈现为HTML 或由 DocBook 的工具链支持的任何其他格式，如 PDF，TeX 的，Unix 的手册页，电子书，幻灯片演示等。
+      | AsciiDoc は、意味的には DocBook XML のに相当するが、プレーン·テキスト·マークアップの規則を使用して、人間が読めるドキュメントフォーマット、である。 AsciiDoc は文書は、任意のテキストエディタを使用して作成され、「そのまま"または、HTML や DocBook のツールチェーンでサポートされている他のフォーマット、すなわち PDF、TeX の、Unix の man ページ、電子書籍、スライドプレゼンテーションなどにレンダリングすることができます。
+      |===
+      EOS
+      lines = pdf.lines
+      (expect lines).to have_size 8
+      (expect lines[0]).to end_with '任何'
+      (expect lines[1]).to start_with '文本'
+      (expect lines[3]).to end_with '使用'
+      (expect lines[4]).to start_with 'して'
+    end
   end
 end


### PR DESCRIPTION
Fix https://github.com/chloerei/asciidoctor-pdf-cjk/issues/4, Also see https://github.com/asciidoctor/asciidoctor-pdf/issues/1206 for details

Require fileutils explictly to fix following errors when run command with `rake spec`

    An error occurred in a `before(:suite)` hook.
    Failure/Error: FileUtils.mkdir_p output_dir

    NameError:
      uninitialized constant FileUtils
      Did you mean?  FileTest
    # ./spec/spec_helper.rb:187:in `block (2 levels) in <top (required)>'