### PR TITLE
resolves #623 partition section title (title and subtitle)

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -10,6 +10,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 * support data URI for SVG image (#1423)
 * account for border offset in width of fragment (#1264)
 * ignore case when sorting index terms (#1405)
+* partition section title (title and subtitle) if `title-separator` document attribute or `separator` block attribute is set (#623)
 * allow output file to be written to stdout (#1411)
 * implement line highlighting for source blocks when using Rouge as source highlighter (#681)
 * implement line highlighting for source blocks when using Pygments as source highlighter (#1444)

--- a/data/themes/base-theme.yml
+++ b/data/themes/base-theme.yml
@@ -25,6 +25,7 @@ role_line-through_text_decoration: line-through
 role_underline_text_decoration: underline
 role_big_font_size: 14
 role_small_font_size: 10
+role_subtitle_font_size: 0.8em
 button_content: '[%s]'
 button_font_family: Courier
 button_font_style: bold

--- a/data/themes/default-theme.yml
+++ b/data/themes/default-theme.yml
@@ -61,6 +61,9 @@ role:
     font_size: $base_font_size_large
   small:
     font_size: $base_font_size_small
+  subtitle:
+    font_size: 0.8em
+    font_color: 999999
 # FIXME vertical_rhythm is weird; we should think in terms of ems
 #vertical_rhythm: $base_line_height_length * 2 / 3
 # correct line height for Noto Serif metrics (comes with built-in line height)

--- a/docs/theming-guide.adoc
+++ b/docs/theming-guide.adoc
@@ -1030,13 +1030,12 @@ This role can be used as follows:
 == [.heading-code]`SELECT` clause
 ----
 
-The converter provides several predefined roles.
+The converter provides several predefined roles, which can can all be redefined.
 The `big` and `small` roles map the font size to the $base-font-size-large and $base-font-size-small values, respectively.
-These two roles can be redefined.
 The `underline` and `line-through` roles add the underline and strikethrough decorations, respectively.
-These two roles _can't_ be redefined.
+The `subtitle` role is used to configure the font properties of the subtitle of a section title.
 The color roles (e.g., `blue`), which you may be familiar with from the HTML converter, are not mapped by default.
-You'll need to define these in your theme if you'd like to make use of them when converting to PDF.
+You'll need to define these color roles in your theme if you'd like to make use of them when converting to PDF.
 
 [cols="3,4,5l"]
 |===

--- a/lib/asciidoctor/pdf/converter.rb
+++ b/lib/asciidoctor/pdf/converter.rb
@@ -534,6 +534,11 @@ module Asciidoctor
 
         type = nil
         title = sect.numbered_title formal: true
+        sep = (sect.attr 'separator', nil, false) || (sect.document.attr 'title-separator') || ''
+        if !sep.empty? && title.include?(sep = %(#{sep} ))
+          title, _, subtitle = title.rpartition sep
+          title = %(#{title}\n<em class="subtitle">#{subtitle}</em>)
+        end
         theme_font :heading, level: (hlevel = sect.level + 1) do
           align = (@theme[%(heading_h#{hlevel}_align)] || @theme.heading_align || @base_align).to_sym
           if sect.part_or_chapter?


### PR DESCRIPTION
- set separator globally using `title-separator` document attribute
- override separator per section title using `separator` block attribute