### PR TITLE
fix footnotes keys control description in theming-guide.adoc

### DIFF
--- a/docs/theming-guide.adoc
+++ b/docs/theming-guide.adoc
@@ -4032,7 +4032,7 @@ Since Asciidoctor 2, table stripes are not enabled by default (e.g., `stripes=no
 [#keys-footnotes]
 === Footnotes
 
-The keys in this catagory control the style the list of footnotes at the end of the chapter (book) or document (otherwise).
+The keys in this catagory control the style of footnotes at the end of the chapter (book) or document (otherwise).
 If the `footnotes-title` attribute is specified, it is styled as a block caption.
 The styling of the links is controlled by the global link styles.
 


### PR DESCRIPTION
Hi Dan,
Happy New Year :-)
To enhance the readability of the theming guide, I simplified the description of the footnotes keys control contents.

If you believe the words "**the list**" shall be kept, just let me know and I will update the PR to modify the description:
- From "_control the style the list of footnotes_"
- To "_control the style_ **of** _the list of footnotes_"

... unless you believe the current sentence is gramatically correct (I am not a native English speaker).