### PR TITLE
Add GitHub Actions script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  build:
+    strategy:
+      matrix:
+        ruby: [jruby, 2.4, 2.7]
+    runs-on: windows-latest
+    env:
+      PYGMENTS_VERSION: ~> 1.2.0
+    steps:
+      - name: Set up Ruby
+        uses: eregon/use-ruby-action@v1.10.0
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build
+        run: |
+          gem install bundler
+          bundle install --jobs 4 --retry 3
+      - name: Test
+        run: bundle exec rake spec


### PR DESCRIPTION
See workflow runs here: https://github.com/slonopotamus/asciidoctor-pdf/actions

This PR cannot be taken as-is because it exposes several problems:

1. [jaro_winkler (rubocop dependency) crashes compiler on Ruby 2.3 + Windows](https://github.com/slonopotamus/asciidoctor-pdf/runs/398410610#step:4:163)
2. [Several tests fail to pass on Windows](https://github.com/slonopotamus/asciidoctor-pdf/runs/398467720#step:4:121). Mostly because they're trying to execute files that are not executable from Windows point of view, but there are some failures that need additional investigation.
WRT running non-executable things, I suggest using `bundle exec <gem_binary>` instead of just `<gem_binary>`, this is more cross-platform.