### PR TITLE
resolves #1503 improve Travis CI build times

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,7 @@ rvm:
 matrix:
   include:
   - rvm: jruby-9.2.9.0
-    env: JRUBY_OPTS='--dev'
   - rvm: jruby-9.1.17.0
-    env: JRUBY_OPTS='--dev'
   - rvm: *oldest_ruby
     env: ASCIIDOCTOR_VERSION=1.5.3
   - rvm: *oldest_ruby

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,33 +8,36 @@ git:
   # use depth 5 to leave enough room for concurrent builds
   depth: 5
 language: ruby
-rvm:
-- &release_ruby 2.7.0
-- 2.6.5
-- 2.5.7
-- 2.4.9
-- &oldest_ruby 2.3.8
-matrix:
+
+jobs:
   include:
   - rvm: jruby-9.2.9.0
   - rvm: jruby-9.1.17.0
+  - rvm: &release_ruby 2.7.0
+  - rvm: 2.6.5
+  - rvm: 2.5.7
+  - rvm: 2.4.9
+  - rvm: &oldest_ruby 2.3.8
   - rvm: *oldest_ruby
     env: ASCIIDOCTOR_VERSION=1.5.3
   - rvm: *oldest_ruby
     env: ROUGE_VERSION='~> 2.0.0'
+
+  - name: Lint
+    rvm: *release_ruby
+    script: bundle exec rake lint
+    deploy:
+      provider: rubygems
+      gem: asciidoctor-pdf
+      api_key: ${RUBYGEMS_API_KEY}
+      on:
+        tags: true
+        repo: asciidoctor/asciidoctor-pdf
+
 env:
   global:
   - PYGMENTS_VERSION='~> 1.2.0'
   - RGHOST_VERSION='0.9.7'
 bundler_args: --path=.bundle/gems --jobs=3 --retry=3 --without=docs
 script:
-- bundle exec rake lint
 - bundle exec ruby -w $(bundle exec ruby -e "print File.join Gem.bindir, 'rake'") spec
-deploy:
-  provider: rubygems
-  gem: asciidoctor-pdf
-  api_key: ${RUBYGEMS_API_KEY}
-  on:
-    tags: true
-    repo: asciidoctor/asciidoctor-pdf
-    rvm: *release_ruby


### PR DESCRIPTION
Note: I am unable to test that release deployment still works.

Wallclock time (with 3 parallel runners) before: ~22min
Wallclock time (with 3 parallel runners) after: ~17min

Jobs are intentionally ordered in such a way that JRuby is in the beginning. It prevents situations when all other jobs have finished, but we're still waiting for JRuby.

Some further improvements could possibly be achieved by using more modern JVM (11 instead of 8) for JRuby.
