### PR TITLE
resolves #1500 disable Travis CI cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,6 @@ addons:
     packages:
     - ghostscript
     - poppler-utils
-cache:
-  bundler: true
-  directories:
-  - $HOME/.rvm
 git:
   # use depth 5 to leave enough room for concurrent builds
   depth: 5
@@ -36,8 +32,6 @@ bundler_args: --path=.bundle/gems --jobs=3 --retry=3 --without=docs
 script:
 - bundle exec rake lint
 - bundle exec ruby -w $(bundle exec ruby -e "print File.join Gem.bindir, 'rake'") spec
-# remove prawn-table so it doesn't get cached and cause cache to be reuploaded
-- bundle info --path prawn-table | xargs -r -IARG rm -rf ARG/.git
 deploy:
   provider: rubygems
   gem: asciidoctor-pdf


### PR DESCRIPTION
Because it doesn't make builds faster.

----

Do not trust what this PR message says, it is just a theory. Check build timings.
