### PR TITLE
Fix bad example per issue #1518

### DIFF
--- a/docs/theming-guide.adoc
+++ b/docs/theming-guide.adoc
@@ -4948,7 +4948,7 @@ These settings override equivalent keys defined in the theme file, where applica
 
 |pdf-page-size
 |https://github.com/prawnpdf/pdf-core/blob/0.6.0/lib/pdf/core/page_geometry.rb#L16-L68[Named size^] {vbar} <<measurement-units,Measurement[width, height]>>
-|:pdf-page-size: 6in x 9in
+|:pdf-page-size: [6in, 9in]
 
 |pdf-folio-placement
 |virtual {vbar} virtual-inverted {vbar} physical {vbar} physical-inverted


### PR DESCRIPTION
The pdf-page-size example in the current docs is incorrect. This update fixes it.