### PR TITLE
Disable Git EOL autoconversion on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+/*file eol=lf
+/bin/* eol=lf
+*.adoc eol=lf
+*.pdf -text
+*.rb eol=lf
+*.svg eol=lf
+*.yml eol=lf


### PR DESCRIPTION
By default ([1]), Git for Windows performs automatic LF->CRLF conversion for text files
when checks them out into working copy.

While this behavior can be desired sometimes, it leads to issues in asciidoctor-pdf:

1. Some PDF files get corrupt, for example examples/basic-example.pdf
2. JRuby doesn't properly parse inline string blocks in Ruby files when they have CRLF line endings

Given that user cannot easily disable CRLF conversion specifically for asciidoctor-pdf repo
when they do `git clone`, this commit completely disables CRLF conversion via .gitattributes.

So, files in working copy will be byte-to-byte identical no matter what platform or environment is used
to checkout asciidoctor-pdf repository.

[1]: https://github.com/git-for-windows/build-extra/blob/master/git-extra/git-extra.install#L9