### PR TITLE
enable CI for Ruby 2.3 on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
         uses: eregon/use-ruby-action@v1.10.0
         with:
           ruby-version: ${{ matrix.ruby }}
-      - name: Bundle
+      - name: Install dependencies
         run: |
-          gem install bundler
-          bundle --path .bundle/gems --jobs 3 --retry 3 --without coverage docs lint
+          gem install bundler --version 2.1.2
+          bundle --jobs 3 --retry 3 --path .bundle/gems --without docs lint coverage
       - name: Test
         run: bundle exec ruby -w $(bundle exec ruby -e "print File.join Gem.bindir, 'rake'") spec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        ruby: [jruby, '2.7', '2.6', '2.5', '2.4']
+        ruby: [jruby, '2.7', '2.6', '2.5', '2.4', '2.3']
     env:
       PYGMENTS_VERSION: '~> 1.2.0'
     steps:
@@ -18,6 +18,6 @@ jobs:
       - name: Bundle
         run: |
           gem install bundler
-          bundle --path .bundle/gems --jobs 3 --retry 3 --without docs
+          bundle --path .bundle/gems --jobs 3 --retry 3 --without coverage docs lint
       - name: Test
         run: bundle exec ruby -w $(bundle exec ruby -e "print File.join Gem.bindir, 'rake'") spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ addons:
 git:
   depth: 5 # use depth 5 to leave enough room for concurrent builds
 language: ruby
-bundler_args: --path .bundle/gems --jobs 3 --retry 3 --without docs
+bundler_args: --path .bundle/gems --jobs 3 --retry 3 --without coverage docs
 env:
   global:
   - PYGMENTS_VERSION='~> 1.2.0'

--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,14 @@ group :docs do
   gem 'yard', require: false
 end
 
+group :lint do
+  unless Gem.win_platform? && RUBY_ENGINE == 'ruby' && (Gem::Version.new RUBY_VERSION) < (Gem::Version.new '2.4.0')
+    gem 'rubocop', '~> 0.78.0', require: false
+    gem 'rubocop-rspec', '~> 1.37.0', require: false
+  end
+end
+
 group :coverage do
-  gem 'deep-cover-core', '~> 0.7.0', require: false if ENV.key? 'COVERAGE'
+  gem 'simplecov', '~> 0.17.0', require: false
+  gem 'deep-cover-core', '~> 0.7.0', require: false
 end

--- a/asciidoctor-pdf.gemspec
+++ b/asciidoctor-pdf.gemspec
@@ -49,13 +49,10 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'treetop', '~> 1.5.0'
 
   s.add_development_dependency 'rake', '~> 13.0.0'
-  s.add_development_dependency 'simplecov', '~> 0.17.0'
   s.add_development_dependency 'rspec', '~> 3.9.0'
   s.add_development_dependency 'pdf-inspector', '~> 1.3.0'
   # Asciidoctor PDF supports Rouge >= 2 (verified in CI build using 2.0.0)
   s.add_development_dependency 'rouge', '~> 3.0'
-  s.add_development_dependency 'rubocop', '~> 0.78.0'
-  s.add_development_dependency 'rubocop-rspec', '~> 1.37.0'
   s.add_development_dependency 'coderay', '~> 1.1.0'
   s.add_development_dependency 'chunky_png', '~> 1.3.0'
 end


### PR DESCRIPTION
- move rubocop deps into group in Gemfile
- exclude lint group when building on Windows
- move simplecov dep to Gemfile