### PR TITLE
resolves #840 allow page mode to be configured using pdf-page-mode attribute or page_mode theme key

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -117,8 +117,9 @@ Style/ParallelAssignment:
 Style/PercentLiteralDelimiters:
   PreferredDelimiters:
     default: ()
-    '%w': ()
+    '%i': ()
     '%r': //
+    '%w': ()
 Style/PerlBackrefs:
   Enabled: false
 Style/RegexpLiteral:

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,6 +8,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 == Unreleased
 
 * draw background and border around entire delimited block with wrapped text that appears inside an AsciiDoc table cell (#820)
+* allow page mode to be fully configured using pdf-page-mode attribute or page_mode theme key (#840)
 
 == 1.5.0.rc.3 (2020-02-04) - @mojavelinux
 

--- a/docs/theming-guide.adoc
+++ b/docs/theming-guide.adoc
@@ -1225,10 +1225,10 @@ See <<Title Page>> for details.
   margin-outer: 0.59in
 
 |mode
-|fullscreen
-(default: _not set_)
+|outline {vbar} none {vbar} thumbs {vbar} fullscreen {vbar} fullscreen outline {vbar} fullscreen none {vbar} fullscreen thumbs +
+(default: outline)
 |page:
-  mode: fullscreen
+  mode: fullscreen none
 
 |size
 |https://github.com/prawnpdf/pdf-core/blob/0.6.0/lib/pdf/core/page_geometry.rb#L16-L68[Named size^] {vbar} <<measurement-units,Measurement[width,height]>> +
@@ -4962,6 +4962,10 @@ These settings override equivalent keys defined in the theme file, where applica
 |pdf-page-margin
 |<<measurement-units,Measurement>> {vbar} <<measurement-units,Measurement[top,right,bottom,left]>>
 |:pdf-page-margin: [1in, 0.5in]
+
+|pdf-page-mode
+|outline {vbar} none {vbar} thumbs {vbar} fullscreen {vbar} fullscreen outline {vbar} fullscreen none {vbar} fullscreen thumbs (default: outline)
+|:pdf-page-mode: fullscreen none
 
 |pdf-page-size
 |https://github.com/prawnpdf/pdf-core/blob/0.6.0/lib/pdf/core/page_geometry.rb#L16-L68[Named size^] {vbar} <<measurement-units,Measurement[width, height]>>

--- a/lib/asciidoctor/pdf/converter.rb
+++ b/lib/asciidoctor/pdf/converter.rb
@@ -48,6 +48,15 @@ module Asciidoctor
       AlignmentTable = { '<' => :left, '=' => :center, '>' => :right }
       ColumnPositions = [:left, :center, :right]
       PageLayouts = [:portrait, :landscape]
+      (PageModes = {
+        'fullscreen' => [:FullScreen, :UseOutlines],
+        'fullscreen none' => [:FullScreen, :UseNone],
+        'fullscreen outline' => [:FullScreen, :UseOutlines],
+        'fullscreen thumbs' => [:FullScreen, :UseThumbs],
+        'none' => :UseNone,
+        'outline' => :UseOutlines,
+        'thumbs' => :UseThumbs,
+      }).default = :UseOutlines
       PageSides = [:recto, :verso]
       (PDFVersions = { '1.3' => 1.3, '1.4' => 1.4, '1.5' => 1.5, '1.6' => 1.6, '1.7' => 1.7 }).default = 1.4
       AuthorAttributeNames = %w(author authorinitials firstname middlename lastname email)
@@ -275,7 +284,6 @@ module Asciidoctor
           layout_running_content :footer, doc, skip: num_front_matter_pages, body_start_page_number: body_start_page_number unless doc.nofooter || @theme.footer_height.to_f == 0
         end
 
-        catalog.data[:PageMode] = :FullScreen if (doc.attr 'pdf-page-mode', @theme.page_mode) == 'fullscreen'
         add_outline doc, (doc.attr 'outlinelevels', toc_num_levels), toc_page_nums, num_front_matter_pages[1], has_front_cover
         if !state.pages.empty? && (initial_zoom = @theme.page_initial_zoom)
           case initial_zoom.to_sym
@@ -3499,7 +3507,9 @@ module Asciidoctor
         toc_section.parent.blocks.delete toc_section if toc_section
 
         catalog.data[:PageLabels] = state.store.ref Nums: pagenum_labels.flatten
-        catalog.data[((doc.attr 'pdf-page-mode') || @theme.page_mode) == 'fullscreen' ? :NonFullScreenPageMode : :PageMode] = :UseOutlines
+        primary_page_mode, secondary_page_mode = PageModes[(doc.attr 'pdf-page-mode') || @theme.page_mode]
+        catalog.data[:PageMode] = primary_page_mode
+        catalog.data[:NonFullScreenPageMode] = secondary_page_mode if secondary_page_mode
         nil
       end
 

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -95,19 +95,79 @@ describe 'Asciidoctor::PDF::Converter - Page' do
   end
 
   context 'Mode' do
-    it 'should set page mode to fullscreen if page_mode key in them is fullscreen' do
+    it 'should set page mode to /UseOutlines by default' do
+      pdf = to_pdf 'content'
+      (expect pdf.catalog[:PageMode]).to be :UseOutlines
+    end
+
+    it 'should set page mode to /UseOutlines if value of page_mode key in theme is outline' do
+      pdf = to_pdf 'content', pdf_theme: { page_mode: 'outline' }
+      (expect pdf.catalog[:PageMode]).to be :UseOutlines
+    end
+
+    it 'should set page mode to /UseOutlines if value of pdf-page-mode attribute is outline' do
+      pdf = to_pdf 'content', attribute_overrides: { 'pdf-page-mode' => 'outline' }
+      (expect pdf.catalog[:PageMode]).to be :UseOutlines
+    end
+
+    it 'should set page mode to /UseNone if value of page_mode key in theme is none' do
+      pdf = to_pdf 'content', pdf_theme: { page_mode: 'none' }
+      (expect pdf.catalog[:PageMode]).to be :UseNone
+    end
+
+    it 'should set page mode to /UseNone if value of pdf-page-mode attribute is none' do
+      pdf = to_pdf 'content', attribute_overrides: { 'pdf-page-mode' => 'none' }
+      (expect pdf.catalog[:PageMode]).to be :UseNone
+    end
+
+    it 'should set page mode to /UseThumbs if value of page_mode key in theme is thumbs' do
+      pdf = to_pdf 'content', pdf_theme: { page_mode: 'thumbs' }
+      (expect pdf.catalog[:PageMode]).to be :UseThumbs
+    end
+
+    it 'should set page mode to /UseThumbs if value of pdf-page-mode attribute is thumbs' do
+      pdf = to_pdf 'content', attribute_overrides: { 'pdf-page-mode' => 'thumbs' }
+      (expect pdf.catalog[:PageMode]).to be :UseThumbs
+    end
+
+    it 'should set page mode to /UseOutlines if value of page_mode key in theme is unrecognized' do
+      pdf = to_pdf 'content', pdf_theme: { page_mode: 'invalid' }
+      (expect pdf.catalog[:PageMode]).to be :UseOutlines
+    end
+
+    it 'should set page mode to /UseOutlines if value of pdf-page-mode attribute is unrecognized' do
+      pdf = to_pdf 'content', attribute_overrides: { 'pdf-page-mode' => 'invalid' }
+      (expect pdf.catalog[:PageMode]).to be :UseOutlines
+    end
+
+    it 'should set page mode to fullscreen if page_mode key in theme is fullscreen' do
       pdf = to_pdf 'content', pdf_theme: { page_mode: 'fullscreen' }
       (expect pdf.catalog[:PageMode]).to be :FullScreen
+      (expect pdf.catalog[:NonFullScreenPageMode]).to be :UseOutlines
     end
 
     it 'should set page mode to fullscreen if pdf-page-mode attribute is fullscreen' do
       pdf = to_pdf 'content', attribute_overrides: { 'pdf-page-mode' => 'fullscreen' }
       (expect pdf.catalog[:PageMode]).to be :FullScreen
+      (expect pdf.catalog[:NonFullScreenPageMode]).to be :UseOutlines
+    end
+
+    it 'should set secondary page mode to none if page_mode key in theme is fullscreen none' do
+      pdf = to_pdf 'content', pdf_theme: { page_mode: 'fullscreen none' }
+      (expect pdf.catalog[:PageMode]).to be :FullScreen
+      (expect pdf.catalog[:NonFullScreenPageMode]).to be :UseNone
+    end
+
+    it 'should set secondary page mode to none if pdf-page-mode attribute is fullscreen none' do
+      pdf = to_pdf 'content', attribute_overrides: { 'pdf-page-mode' => 'fullscreen none' }
+      (expect pdf.catalog[:PageMode]).to be :FullScreen
+      (expect pdf.catalog[:NonFullScreenPageMode]).to be :UseNone
     end
 
     it 'should allow pdf-page-mode attribute in document to disable fullscreen mode' do
       pdf = to_pdf 'content', pdf_theme: { page_mode: 'fullscreen' }, attribute_overrides: { 'pdf-page-mode' => '' }
       (expect pdf.catalog[:PageMode]).not_to be :FullScreen
+      (expect pdf.catalog).not_to have_key :NonFullScreenPageMode
     end
   end
 


### PR DESCRIPTION
- in additional to fullscreen, recognize all valid combinations for page mode
- OC and Attachments are not supported at this time (since Asciidoctor PDF doesn't make use of those features)
- document the pdf-page-mode attribute in the theming guide