### PR TITLE
relax dependency on concurrent-ruby

### DIFF
--- a/asciidoctor-pdf.gemspec
+++ b/asciidoctor-pdf.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'prawn-icon', '~> 2.5.0'
   s.add_runtime_dependency 'safe_yaml', '~> 1.0.0'
   s.add_runtime_dependency 'thread_safe', '~> 0.3.0'
-  s.add_runtime_dependency 'concurrent-ruby', '~> 1.1.0'
+  s.add_runtime_dependency 'concurrent-ruby', '~> 1.1'
   s.add_runtime_dependency 'treetop', '~> 1.6.0'
 
   s.add_development_dependency 'rake', '~> 13.0.0'


### PR DESCRIPTION
concurrent-ruby is compliant with semantic versioning https://github.com/ruby-concurrency/concurrent-ruby#versioning so ~> 1.1 is enough