### PR TITLE
Handle rename of eregon/use-ruby-action to ruby/setup-ruby

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Install Ruby
-      uses: eregon/use-ruby-action@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
     - name: Configure Bundler


### PR DESCRIPTION
While action is available via both names, former one is deprecated.