### PR TITLE
resolves #1542 fix numeric assertions in test suite

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -68,6 +68,7 @@ Bug Fixes::
 * use informal title prefixed with down indicator for collapsible block (#1660)
 * don't apply border, shading, or padding to collapsible block (#1660)
 * escape bare ampersand in attribution and citetitle of quote or verse block (#1662)
+* fix numeric assertions in test suite (#1542)
 
 Compliance::
 

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -35,7 +35,7 @@ describe 'asciidoctor-pdf' do
       (expect err).to be_empty
       (expect Pathname.new output_file 'hello.pdf').to exist
     end
-  end
+  end if defined? Bundler
 
   context 'Examples' do
     it 'should convert the basic example', cli: true, visual: true do

--- a/spec/cover_page_spec.rb
+++ b/spec/cover_page_spec.rb
@@ -295,7 +295,7 @@ describe 'Asciidoctor::PDF::Converter - Cover Page' do
     (expect images).to have_size 1
     cover_image = images[0]
     (expect cover_image[:x].to_f).to eql 0.0
-    (expect cover_image[:width]).to eql pdf_page_size[0]
+    (expect cover_image[:width]).to eql pdf_page_size[0].to_f
     (expect cover_image[:height]).to be > pdf_page_size[1]
     (expect cover_image[:y]).to be > pdf_page_size[1]
   end
@@ -342,7 +342,7 @@ describe 'Asciidoctor::PDF::Converter - Cover Page' do
     pdf = to_pdf input, analyze: true
     (expect pdf.pages).to have_size 2
     (expect pdf.pages[0][:text]).to be_empty
-    (expect pdf.pages[0][:size]).to eql PDF::Core::PageGeometry::SIZES['LETTER']
+    (expect pdf.pages[0][:size].map(&:to_f)).to eql PDF::Core::PageGeometry::SIZES['LETTER']
     (expect pdf.pages[1][:size]).to eql PDF::Core::PageGeometry::SIZES['A4']
     (expect pdf.pages[1][:text]).not_to be_empty
   end

--- a/spec/font_spec.rb
+++ b/spec/font_spec.rb
@@ -345,7 +345,7 @@ describe 'Asciidoctor::PDF::Converter - Font' do
       }
       pdf = to_pdf 'https://asciidoctor.org[Asciidoctor]', pdf_theme: pdf_theme, analyze: true
       linked_text = (pdf.find_text 'Asciidoctor')[0]
-      (expect linked_text[:font_size]).to eql 9.0
+      (expect linked_text[:font_size].to_f).to eql 9.0
     end
   end
 end

--- a/spec/formatted_text_formatter_spec.rb
+++ b/spec/formatted_text_formatter_spec.rb
@@ -505,9 +505,9 @@ describe Asciidoctor::PDF::FormattedText::Formatter do
       min_text = (pdf.find_text 'MIN')[0]
       normal_text = (pdf.find_text ' and ')[0]
       max_text = (pdf.find_text 'MAX')[0]
-      (expect min_text[:font_size]).to eql 18.0
+      (expect min_text[:font_size].to_f).to eql 18.0
       (expect normal_text[:font_size]).to be 24
-      (expect max_text[:font_size]).to eql 21.0
+      (expect max_text[:font_size].to_f).to eql 21.0
     end
 
     it 'should allow custom role to override styles of link' do

--- a/spec/hyphens_spec.rb
+++ b/spec/hyphens_spec.rb
@@ -156,4 +156,4 @@ describe 'Asciidoctor::PDF::Converter - Hyphens' do
 
     (expect to_file).to visually_match 'hyphens-word-break.pdf'
   end
-end
+end unless (Gem::Specification.stubs_for 'text-hyphen').empty?

--- a/spec/image_spec.rb
+++ b/spec/image_spec.rb
@@ -343,7 +343,7 @@ describe 'Asciidoctor::PDF::Converter - Image' do
       text = pdf.find_text 'Text with link'
       (expect text).to have_size 1
       (expect text[0][:font_name]).to eql 'mplus1mn-regular'
-      (expect text[0][:font_size]).to eql 12.0
+      (expect text[0][:font_size].to_f).to eql 12.0
       (expect text[0][:font_color]).to eql 'AA0000'
     end
 
@@ -355,7 +355,7 @@ describe 'Asciidoctor::PDF::Converter - Image' do
       text = pdf.find_text 'This text uses a document font.'
       (expect text).to have_size 1
       (expect text[0][:font_name]).to eql 'mplus1mn-regular'
-      (expect text[0][:font_size]).to eql 12.0
+      (expect text[0][:font_size].to_f).to eql 12.0
       (expect text[0][:font_color]).to eql 'AA0000'
     end
 
@@ -367,7 +367,7 @@ describe 'Asciidoctor::PDF::Converter - Image' do
       text = pdf.find_text 'This text uses the default SVG font.'
       (expect text).to have_size 1
       (expect text[0][:font_name]).to eql 'NotoSerif'
-      (expect text[0][:font_size]).to eql 12.0
+      (expect text[0][:font_size].to_f).to eql 12.0
       (expect text[0][:font_color]).to eql 'AA0000'
     end
 
@@ -379,7 +379,7 @@ describe 'Asciidoctor::PDF::Converter - Image' do
       text = pdf.find_text 'This text uses the serif font.'
       (expect text).to have_size 1
       (expect text[0][:font_name]).to eql 'Times-Roman'
-      (expect text[0][:font_size]).to eql 12.0
+      (expect text[0][:font_size].to_f).to eql 12.0
       (expect text[0][:font_color]).to eql 'AA0000'
     end
 
@@ -393,7 +393,7 @@ describe 'Asciidoctor::PDF::Converter - Image' do
       text = pdf.find_text 'This text uses the serif font.'
       (expect text).to have_size 1
       (expect text[0][:font_name]).to eql 'NotoSerif'
-      (expect text[0][:font_size]).to eql 12.0
+      (expect text[0][:font_size].to_f).to eql 12.0
       (expect text[0][:font_color]).to eql 'AA0000'
     end
 
@@ -408,7 +408,7 @@ describe 'Asciidoctor::PDF::Converter - Image' do
         text = pdf.find_text 'This text uses the default SVG font.'
         (expect text).to have_size 1
         (expect text[0][:font_name]).to eql 'Times-Roman'
-        (expect text[0][:font_size]).to eql 12.0
+        (expect text[0][:font_size].to_f).to eql 12.0
         (expect text[0][:font_color]).to eql 'AA0000'
       end
     end
@@ -619,7 +619,7 @@ describe 'Asciidoctor::PDF::Converter - Image' do
       (expect pages).to have_size 3
       (expect pages[0][:size]).to eql PDF::Core::PageGeometry::SIZES['A4']
       (expect pages[0][:text][-1][:string]).to eql '1'
-      (expect pages[1][:size]).to eql PDF::Core::PageGeometry::SIZES['LETTER']
+      (expect pages[1][:size].map(&:to_f)).to eql PDF::Core::PageGeometry::SIZES['LETTER']
       # NOTE no running content on imported pages
       (expect pages[1][:text]).to be_empty
       (expect pages[2][:text][-1][:string]).to eql '3'
@@ -644,7 +644,7 @@ describe 'Asciidoctor::PDF::Converter - Image' do
       (expect pages).to have_size 3
       (expect pages[0][:size]).to eql PDF::Core::PageGeometry::SIZES['A4']
       (expect pages[0][:text][-1][:string]).to eql '1'
-      (expect pages[1][:size]).to eql PDF::Core::PageGeometry::SIZES['LETTER']
+      (expect pages[1][:size].map(&:to_f)).to eql PDF::Core::PageGeometry::SIZES['LETTER']
       # NOTE no running content on imported pages
       (expect pages[1][:text]).to be_empty
       (expect pages[2][:text][-1][:string]).to eql '3'
@@ -990,7 +990,7 @@ describe 'Asciidoctor::PDF::Converter - Image' do
           OpenURI::Cache.invalidate image_url
         end
       end
-    end
+    end unless (Gem::Specification.stubs_for 'open-uri-cached').empty?
   end
 
   context 'Inline' do

--- a/spec/image_spec.rb
+++ b/spec/image_spec.rb
@@ -439,7 +439,7 @@ describe 'Asciidoctor::PDF::Converter - Image' do
       end).to log_message severity: :WARN, message: %(~problem encountered in image: #{fixture_file 'svg-with-remote-image.svg'}; Error retrieving URL https://cdn.jsdelivr.net/gh/asciidoctor/asciidoctor-pdf@v1.5.0.rc.2/spec/fixtures/logo.png)
     end
 
-    it 'should embed remote image if allow allow-uri-read attribute is set', visual: true do
+    it 'should embed remote image if allow allow-uri-read attribute is set', visual: true, network: true do
       to_file = to_pdf_file <<~'EOS', 'image-svg-with-remote-image.pdf', attribute_overrides: { 'allow-uri-read' => '' }
       A sign of a good writer: image:svg-with-remote-image.svg[]
       EOS
@@ -903,7 +903,7 @@ describe 'Asciidoctor::PDF::Converter - Image' do
       (expect (pdf.page 1).text).to be_empty
     end
 
-    it 'should read remote image over HTTPS if allow-uri-read is set' do
+    it 'should read remote image over HTTPS if allow-uri-read is set', network: true do
       pdf = to_pdf 'image::https://cdn.jsdelivr.net/gh/asciidoctor/asciidoctor-pdf@v1.5.0.rc.2/spec/fixtures/logo.png[Remote Image]', attribute_overrides: { 'allow-uri-read' => '' }
       images = get_images pdf, 1
       (expect images).to have_size 1

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -19,7 +19,8 @@ describe 'Asciidoctor::PDF::Converter - Page' do
       content
       EOS
       (expect pdf.pages).to have_size 1
-      (expect pdf.pages[0][:size]).to eql PDF::Core::PageGeometry::SIZES['LETTER']
+      # NOTE pdf-core 0.8 coerces whole number floats to integers
+      (expect pdf.pages[0][:size].map(&:to_f)).to eql PDF::Core::PageGeometry::SIZES['LETTER']
     end
 
     it 'should ignore pdf-page-size attribute if value is unrecognized name' do
@@ -39,7 +40,7 @@ describe 'Asciidoctor::PDF::Converter - Page' do
       content
       EOS
       (expect pdf.pages).to have_size 1
-      (expect pdf.pages[0][:size]).to eql [600.0, 800.0]
+      (expect pdf.pages[0][:size].map(&:to_f)).to eql [600.0, 800.0]
     end
 
     it 'should set page size specified by pdf-page-size attribute using dimension array in inches' do
@@ -49,7 +50,7 @@ describe 'Asciidoctor::PDF::Converter - Page' do
       content
       EOS
       (expect pdf.pages).to have_size 1
-      (expect pdf.pages[0][:size]).to eql PDF::Core::PageGeometry::SIZES['LETTER']
+      (expect pdf.pages[0][:size].map(&:to_f)).to eql PDF::Core::PageGeometry::SIZES['LETTER']
     end
 
     it 'should set page size specified by pdf-page-size attribute using dimension string in inches' do
@@ -59,7 +60,7 @@ describe 'Asciidoctor::PDF::Converter - Page' do
       content
       EOS
       (expect pdf.pages).to have_size 1
-      (expect pdf.pages[0][:size]).to eql PDF::Core::PageGeometry::SIZES['LETTER']
+      (expect pdf.pages[0][:size].map(&:to_f)).to eql PDF::Core::PageGeometry::SIZES['LETTER']
     end
   end
 

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -749,7 +749,7 @@ describe 'Asciidoctor::PDF::Converter - Page' do
       (expect to_file).to visually_match 'page-background-image-fill.pdf'
     end
 
-    it 'should allow remote image in SVG to be read if allow-uri-read attribute is set', visual: true do
+    it 'should allow remote image in SVG to be read if allow-uri-read attribute is set', visual: true, network: true do
       to_file = to_pdf_file <<~'EOS', 'page-background-image-svg-with-remote-image.pdf', attribute_overrides: { 'allow-uri-read' => '' }
       :page-background-image: image:svg-with-remote-image.svg[fit=none,position=top]
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ elsif ENV['COVERAGE'] == 'true'
 end
 
 require 'asciidoctor/pdf'
+require 'prawn/table/version'
 require 'base64'
 require 'chunky_png'
 require 'fileutils' unless defined? FileUtils

--- a/spec/table_spec.rb
+++ b/spec/table_spec.rb
@@ -389,8 +389,15 @@ describe 'Asciidoctor::PDF::Converter - Table' do
       |===
       EOS
 
-      (expect pdf.find_text 'Operation').not_to be_empty
-      (expect pdf.find_text 'Operator').not_to be_empty
+      if (Gem::Version.new Prawn::Table::VERSION) > (Gem::Version.new '0.2.2')
+        (expect pdf.find_text 'Operation').not_to be_empty
+        (expect pdf.find_text 'Operator').not_to be_empty
+      else
+        (expect pdf.find_text 'Operation').to be_empty
+        (expect pdf.find_text 'Operatio').not_to be_empty
+        (expect pdf.find_text 'Operator').to be_empty
+        (expect pdf.find_text 'Operato').not_to be_empty
+      end
     end
 
     it 'should not break words in body rows when autowidth option is set' do

--- a/spec/video_spec.rb
+++ b/spec/video_spec.rb
@@ -14,7 +14,7 @@ describe 'Asciidoctor::PDF::Converter - Video' do
   end
 
   context 'YouTube' do
-    it 'should replace video with poster image if allow-uri-read attribute is set', visual: true do
+    it 'should replace video with poster image if allow-uri-read attribute is set', visual: true, network: true do
       video_id = 'EJ09pSuA9hw'
       to_file = to_pdf_file <<~EOS, 'video-youtube-poster.pdf', attribute_overrides: { 'allow-uri-read' => '' }
       video::#{video_id}[youtube,pdfwidth=100%]
@@ -31,7 +31,7 @@ describe 'Asciidoctor::PDF::Converter - Video' do
   end
 
   context 'Vimeo' do
-    it 'should replace video with poster image if allow-uri-read attribute is set', visual: true do
+    it 'should replace video with poster image if allow-uri-read attribute is set', visual: true, network: true do
       video_id = '77477140'
       to_file = to_pdf_file <<~EOS, 'video-vimeo-poster.pdf', attribute_overrides: { 'allow-uri-read' => '' }
       video::#{video_id}[vimeo,pdfwidth=100%]


### PR DESCRIPTION
- account for the fact that pdf-core 0.8.1 truncates whole number floats
- disable hyphens and URI cache tests if gems not available