### PR TITLE
resolves #1715 use more specific regexp for hyphenation

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -99,6 +99,7 @@ Bug Fixes::
 * use correct spacing for dotted border dash on table (length and spacing should match width)
 * set color space on page with only image so font color is preserved in running content (#1742)
 * compute font size for superscript and subscript correctly when parent element uses em units (#1745)
+* respect hyphenation exceptions when word is adjacent to non-word character (#1715)
 
 Compliance::
 

--- a/lib/asciidoctor/pdf/text_transformer.rb
+++ b/lib/asciidoctor/pdf/text_transformer.rb
@@ -6,10 +6,10 @@ module Asciidoctor
       XMLMarkupRx = /&#?[a-z\d]+;|</
       PCDATAFilterRx = /(&#?[a-z\d]+;|<[^>]+>)|([^&<]+)/
       TagFilterRx = /(<[^>]+>)|([^<]+)/
-      WordRx = /\S+/
+      ContiguousCharsRx = /\p{Graph}+/
+      WordRx = /\p{Word}+/
       Hyphen = '-'
       SoftHyphen = ?\u00ad
-      HyphenatedHyphen = '-' + SoftHyphen
 
       def capitalize_words_pcdata string
         if XMLMarkupRx.match? string
@@ -20,7 +20,7 @@ module Asciidoctor
       end
 
       def capitalize_words string
-        string.gsub(WordRx) { $&.capitalize }
+        string.gsub(ContiguousCharsRx) { $&.capitalize }
       end
 
       def hyphenate_words_pcdata string, hyphenator
@@ -32,7 +32,7 @@ module Asciidoctor
       end
 
       def hyphenate_words string, hyphenator
-        string.gsub(WordRx) { (hyphenator.visualize $&, SoftHyphen).gsub HyphenatedHyphen, Hyphen }
+        string.gsub(WordRx) { hyphenator.visualize $&, SoftHyphen }
       end
 
       def lowercase_pcdata string

--- a/spec/hyphens_spec.rb
+++ b/spec/hyphens_spec.rb
@@ -40,6 +40,24 @@ describe 'Asciidoctor::PDF::Converter - Hyphens' do
     (expect pdf.lines[0]).to end_with '-'
   end
 
+  it 'should honor hyphenation exceptions when word is adjacent to a non-word character' do
+    pdf = to_pdf <<~'EOS', analyze: true
+    :hyphens:
+    :lang: nl
+
+    [width=15%]
+    |===
+    | souveniertjes!
+    |===
+    EOS
+
+    (expect pdf.lines).to eql [%(souve\u00ad), 'niertjes!']
+
+    converter = Asciidoctor::Converter.create 'pdf'
+    result = converter.hyphenate_words 'souveniertjes!', (Text::Hyphen.new language: 'nl')
+    (expect result).to eql %(sou\u00adve\u00adniertjes!)
+  end
+
   it 'should hyphenate text in table cell in table head if hyphens attribute is set' do
     pdf = to_pdf <<~'EOS', analyze: true
     :hyphens:


### PR DESCRIPTION
This resolves #1715 by using the `[[:word:]]` character class instead of all non-whitespace characters for tokenization.

I decided to use unit tests for this instead of integration tests, since that gave me more control over the exceptions (such that it is independent of possible changes in the language files) and made it easier to check the output. However, as I'm completely new to Ruby, the implementation may not conform to some best practices. So please let me know if there is something that can be improved.