### PR TITLE
resolves #1726 prevent PDF import from corrupting references in PDF

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -92,6 +92,7 @@ Bug Fixes::
 * allow an index term to be defined in section title with auto-generated ID
 * fix alignment of link box for image in running content with numeric vertical alignment
 * short-circuit xreftext containing a circular reference path
+* prevent PDF page import from corrupting references in PDF (#1726)
 
 Compliance::
 

--- a/lib/asciidoctor/pdf/converter.rb
+++ b/lib/asciidoctor/pdf/converter.rb
@@ -279,8 +279,8 @@ module Asciidoctor
           end
 
           @index.start_page_number = num_front_matter_pages[1] + 1
-          doc.set_attr 'pdf-anchor', (doc_anchor = derive_anchor_from_id doc.id, 'top')
-          add_dest_for_block doc, doc_anchor
+          doc.set_attr 'pdf-anchor', (derive_anchor_from_id doc.id, 'top')
+          doc.set_attr 'pdf-page-start', page_number
 
           convert_section generate_manname_section doc if doc.doctype == 'manpage' && (doc.attr? 'manpurpose')
 
@@ -316,6 +316,7 @@ module Asciidoctor
 
         stamp_foreground_image doc, has_front_cover
         layout_cover_page doc, :back
+        add_dest_for_top doc
         nil
       end
 
@@ -4052,6 +4053,16 @@ module Asciidoctor
         else
           %(__anchor-#{default_value})
         end
+      end
+
+      def add_dest_for_top doc
+        unless (top_page = doc.attr 'pdf-page-start') > page_count
+          pg = page_number
+          go_to_page top_page
+          add_dest_for_block doc, (doc.attr 'pdf-anchor')
+          go_to_page pg
+        end
+        nil
       end
 
       # If an id is provided or the node passed as the first argument has an id,

--- a/lib/asciidoctor/pdf/ext/prawn/extensions.rb
+++ b/lib/asciidoctor/pdf/ext/prawn/extensions.rb
@@ -776,14 +776,9 @@ module Asciidoctor
       def delete_page
         pg = page_number
         pdf_store = state.store
-        pdf_objs = pdf_store.instance_variable_get :@objects
-        pdf_ids = pdf_store.instance_variable_get :@identifiers
-        page_id = pdf_store.object_id_for_page pg
         content_id = page.content.identifier
-        [page_id, content_id].each do |key|
-          pdf_objs.delete key
-          pdf_ids.delete key
-        end
+        # NOTE: cannot delete objects and IDs, otherwise references get corrupted; so just reset the value
+        (pdf_store.instance_variable_get :@objects)[content_id] = ::PDF::Core::Reference.new content_id, {}
         pdf_store.pages.data[:Kids].pop
         pdf_store.pages.data[:Count] -= 1
         state.pages.pop

--- a/spec/dest_spec.rb
+++ b/spec/dest_spec.rb
@@ -3,6 +3,15 @@
 require_relative 'spec_helper'
 
 describe 'Asciidoctor::PDF::Converter - Dest' do
+  it 'should not define a dest named __anchor-top if document has no body pages' do
+    pdf = to_pdf <<~'EOS'
+    = Document Title
+    :doctype: book
+    EOS
+    names = get_names pdf
+    (expect names).to be_empty
+  end
+
   it 'should define a dest named __anchor-top at top of the first body page' do
     pdf = to_pdf <<~'EOS'
     = Document Title

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -474,8 +474,12 @@ RSpec.configure do |config|
   end
 
   def get_names pdf
-    objects = pdf.objects
-    Hash[*objects[objects[pdf.catalog[:Names]][:Dests]][:Names]]
+    if (names = pdf.catalog[:Names])
+      objects = pdf.objects
+      Hash[*objects[objects[names][:Dests]][:Names]]
+    else
+      {}
+    end
   end
 
   def get_page_labels pdf


### PR DESCRIPTION
- add dest for top at end of conversion
- reset page object instead of deleting reference
- add test to verify dest for top not created if document has no body pages