### PR TITLE
resolves #1813 support power operator in theme

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -57,6 +57,7 @@ Enhancements::
 * allow path of ghostscript command to be controlled using `GS` env var (#1791)
 * only extend theme in extends hierarchy once unless modified with !important (#1800)
 * add print-optimized themes (default-for-print and default-for-print-with-fallback-font) (#1699)
+* add support for power operator in theme (with same precedence as multiply and divide) (#1813)
 
 Bug Fixes::
 

--- a/lib/asciidoctor/pdf/theme_loader.rb
+++ b/lib/asciidoctor/pdf/theme_loader.rb
@@ -18,7 +18,7 @@ module Asciidoctor
       VariableRx = /\$([a-z0-9_-]+)/
       LoneVariableRx = /^\$([a-z0-9_-]+)$/
       HexColorEntryRx = /^(?<k> *\p{Graph}+): +(?!null$)(?<q>["']?)(?<h>#)?(?<v>[a-fA-F0-9]{3,6})\k<q> *(?:#.*)?$/
-      MultiplyDivideOpRx = /(-?\d+(?:\.\d+)?) +([*\/]) +(-?\d+(?:\.\d+)?)/
+      MultiplyDivideOpRx = /(-?\d+(?:\.\d+)?) +([*\/^]) +(-?\d+(?:\.\d+)?)/
       AddSubtractOpRx = /(-?\d+(?:\.\d+)?) +([+\-]) +(-?\d+(?:\.\d+)?)/
       PrecisionFuncRx = /^(round|floor|ceil)\(/
 
@@ -218,8 +218,8 @@ module Asciidoctor
         # NOTE: leave % as a string; handled by converter for now
         original, expr = expr, (resolve_measurement_values expr)
         loop do
-          if (expr.count '*/') > 0
-            result = expr.gsub(MultiplyDivideOpRx) { $1.to_f.send $2.to_sym, $3.to_f }
+          if (expr.count '*/^') > 0
+            result = expr.gsub(MultiplyDivideOpRx) { $1.to_f.send ($2 == '^' ? '**' : $2).to_sym, $3.to_f }
             unchanged = (result == expr)
             expr = result
             break if unchanged

--- a/spec/theme_loader_spec.rb
+++ b/spec/theme_loader_spec.rb
@@ -1084,6 +1084,7 @@ describe Asciidoctor::PDF::ThemeLoader do
         line_height: $base_line_height_length / $base_font_size
         font_size_large: $base_font_size * 1.25
         font_size_min: $base_font_size * 3 / 4
+        border_radius: 3 ^ 2
       blockquote:
         border_width: 5
         padding:  [0, $base_line_height_length - 2, $base_line_height_length * -0.75, $base_line_height_length + $blockquote_border_width / 2]
@@ -1092,6 +1093,7 @@ describe Asciidoctor::PDF::ThemeLoader do
       (expect theme.base_line_height).to eql 1.2
       (expect theme.base_font_size_large).to eql 12.5
       (expect theme.base_font_size_min).to eql 7.5
+      (expect theme.base_border_radius).to eql 9
       (expect theme.blockquote_padding).to eql [0, 10, -9, 14.5]
     end
 


### PR DESCRIPTION
- power operator has same precedence as multiply and divide
- like other operators, must be surrounded by a space on either side