### PR TITLE
convert LICENSE file to text format

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -8,5 +8,5 @@
 lib/**/*.rb
 -
 CHANGELOG.adoc
-LICENSE.adoc
+LICENSE
 NOTICE.adoc

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
-.The MIT License
-....
+MIT License
+
 Copyright (C) 2014-2020 OpenDevise Inc. and the Asciidoctor Project
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,4 +19,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-....

--- a/README.adoc
+++ b/README.adoc
@@ -40,7 +40,6 @@ endif::[]
 ifdef::status[]
 image:{url-project-repo}/workflows/CI/badge.svg[Build Status (GitHub Actions),link={url-project-repo}/actions?query=workflow%3ACI+branch%3Amaster]
 image:https://img.shields.io/gem/v/asciidoctor-pdf.svg[Latest Release, link={url-gem}]
-image:https://img.shields.io/badge/license-MIT-blue.svg[MIT License, link=#copyright]
 endif::[]
 
 Asciidoctor PDF is a native PDF converter for AsciiDoc.
@@ -1286,5 +1285,5 @@ To help develop {project-name}, or to simply use the development version, refer 
 Copyright (C) 2014-2020 OpenDevise Inc. and the Asciidoctor Project.
 Free use of this software is granted under the terms of the MIT License.
 
-For the full text of the license, see the <<LICENSE.adoc#,LICENSE>> file.
+For the full text of the license, see the link:LICENSE[] file.
 Refer to the <<NOTICE.adoc#,NOTICE>> file for information about third-party Open Source software in use.


### PR DESCRIPTION
This commit allows GitHub to properly detect project license as seen on main project page, organization repository list and other places.

Before:
![image](https://user-images.githubusercontent.com/92637/100347636-bd572f80-2ff6-11eb-8736-14370afb2ac8.png)

After:
![image](https://user-images.githubusercontent.com/92637/100347810-027b6180-2ff7-11eb-8101-e3008483188f.png)
