### PR TITLE
upgrade to Prawn 2.4

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -146,7 +146,7 @@ Compliance::
 * drop support for versions of Asciidoctor < 2 (#1552)
 * drop support for Ruby < 2.5 (which includes JRuby 9.1) (#1681)
 * release lock on ttfunk version (1.6 produces slightly different output from 1.5 for certain missing glyphs)
-* upgrade to Prawn 2.3.0 (which adds OTF font support)
+* upgrade to Prawn 2.3.0 (which adds OTF font support), then to Prawn 2.4.0
 * upgrade to prawn-svg 0.31 (adds support for loading embedded images from a data URI)
 * drop deprecated Pdf module alias in API (leaving only PDF)
 * remove deprecated "ascii" fonts; only bundle the more complete "subset" fonts

--- a/asciidoctor-pdf.gemspec
+++ b/asciidoctor-pdf.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   #s.test_files = files.grep %r/^(?:test|spec|feature)\/.*$/
 
   s.add_runtime_dependency 'asciidoctor', '~> 2.0'
-  s.add_runtime_dependency 'prawn', '~> 2.3.0'
+  s.add_runtime_dependency 'prawn', '~> 2.4.0'
   # NOTE must use prawn-table from master branch (defined in Gemfile) for full functionality
   s.add_runtime_dependency 'prawn-table', '~> 0.2.0'
   s.add_runtime_dependency 'prawn-templates', '~> 0.1.0'


### PR DESCRIPTION
- allows gem to be installed on Ruby 3