### PR TITLE
Modify subset-fonts.pe to add floor/ceiling characters

### DIFF
--- a/scripts/subset-fonts.pe
+++ b/scripts/subset-fonts.pe
@@ -228,6 +228,10 @@ while (fi < num_copy_fonts)
         SelectMore(0uff00,0uffef)
         # CJK Unified Ideographs (for Japanese, aka kanji) (not present in mainstream Noto Serif fonts)
         SelectMore(0u4e00,0u9faf)
+        # Additional requested special characters (mostly math) - see issue 1832
+        # harr, cdot, downarrow, elem, land, lor, oplus, lceil, rceil, lfloor,
+        # rfloor, forall, check
+        SelectMoreSingletons(0u2194,0u22C5,0u2193,0u2208,0u2227,0u2228,0u2295,0u2308,0u2309,0u230A,0u230B,0u2200,0u2713)
       endif
     endif
     #if (script == "fallback")


### PR DESCRIPTION
This follows advice in #1832 on how to add some missing characters in the M+ fallback font. I think the floor/ceiling characters are the only ones not already present, but
my branch explicitly tags all the glyphs the Vulkan spec requires that
aren't in the bundled (non-fallback) fonts, for possible future
reference.

The change to the bundled font is very small - about 220 bytes - and I
hope it can be included with asciidoctor-pdf going forward.

I had problems building from the repository scripts, as I don't have
much of the infrastructure the entire repository expects. In addition
there was some sort of issue with a mis-named font in subset-fonts.sh
relative to HEAD at the time I did the change. Eventually I cobbled
together a shell script which modified subset-fonts.sh and let me build
the one font I needed (the M+ fallback) locally using fontforge, without
using podman, and have verified that works for us.

Closes #1832