### PR TITLE
Fix #1897

### DIFF
--- a/lib/asciidoctor/pdf/converter.rb
+++ b/lib/asciidoctor/pdf/converter.rb
@@ -1741,7 +1741,6 @@ module Asciidoctor
 
       # QUESTION: can we avoid arranging fragments multiple times (conums & autofit) by eagerly preparing arranger?
       def convert_listing_or_literal node
-        add_dest_for_block node if node.id
         wrap_ext = source_chunks = bg_color_override = font_color_override = adjusted_font_size = nil
         theme_font :code do
           # HACK: disable built-in syntax highlighter; must be done before calling node.content!
@@ -1875,6 +1874,7 @@ module Asciidoctor
         theme_margin :block, :top
 
         keep_together do |box_height = nil|
+          add_dest_for_block node if node.id && box_height
           caption_height = node.title? ? (layout_caption node, category: :code) : 0
           theme_font :code do
             theme_fill_and_stroke_block :code, (box_height - caption_height), background_color: bg_color_override, split_from_top: false if box_height


### PR DESCRIPTION
When converting listing blocks, add PDF link destination after `dry_run` phase of `keep_together` to keep the link destination and the block together.

fixes #1897 (I think :smile:)