### PR TITLE
resolves #1909 improve warning about missing characters in fonts

### DIFF
--- a/lib/asciidoctor/pdf/ext/prawn/formatted_text/box.rb
+++ b/lib/asciidoctor/pdf/ext/prawn/formatted_text/box.rb
@@ -56,7 +56,7 @@ Prawn::Text::Formatted::Box.prepend (Module.new do
             (doc.instance_variable_get :@missing_chars) : (doc.instance_variable_set :@missing_chars, {})
         previous_fonts_checked = (missing_chars[char] ||= [])
         if previous_fonts_checked.empty? && !(previous_fonts_checked.include? fonts_checked)
-          logger.warn %(Could not locate the character `#{char}' in the following fonts: #{fonts_checked.join ', '})
+          logger.warn %(Could not locate the character `#{char}' (#{char.unpack('U*').map {|it| "\\u#{(it.to_s 16).rjust 4, '0'}" }.join}) in the following fonts: #{fonts_checked.join ', '})
           previous_fonts_checked << fonts_checked
         end
       end

--- a/spec/font_spec.rb
+++ b/spec/font_spec.rb
@@ -95,7 +95,7 @@ describe 'Asciidoctor::PDF::Converter - Font' do
         input = input_lines.join %(\n\n)
         pdf = to_pdf input, attribute_overrides: { 'pdf-theme' => 'default-with-fallback-font' }, analyze: true
         (expect pdf.lines).to eql input_lines
-      end).to log_message severity: :WARN, message: %(Could not locate the character `\u20bf' in the following fonts: Noto Serif, M+ 1p Fallback, Noto Emoji), using_log_level: :INFO
+      end).to log_message severity: :WARN, message: %(Could not locate the character `\u20bf' (\\u20bf) in the following fonts: Noto Serif, M+ 1p Fallback, Noto Emoji), using_log_level: :INFO
     end
   end
 


### PR DESCRIPTION
by adding an escaped unicode format to the message.


 