### PR TITLE
resolves #1990 handle uppercase characters in character references

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -65,6 +65,7 @@ Enhancements::
 * allow theme to control top margin of callout lists that immediately follow a code (i.e., listing, literal, or source) block (#1895)
 * introduce layout_general_heading to allow extended converter to access node (#1904)
 * use Document#authors to retrieve authors instead of extracting the information from the indexed document attributes
+* add support for character references that contain both uppercase and lowercase hexadecimal characters (#1990) (*@etiwnad*)
 
 Bug Fixes::
 

--- a/lib/asciidoctor/pdf/ext/pygments.rb
+++ b/lib/asciidoctor/pdf/ext/pygments.rb
@@ -4,8 +4,8 @@ module Pygments
   module Ext
     module BlockStyles
       BlockSelectorRx = /^\.highlight *\{([^}]+?)\}/
-      HighlightBackgroundColorRx = /^\.highlight +\.hll +{ *background(?:-color)?: *#([a-fA-F0-9]{6})/
-      ColorPropertiesRx = /(?:^|;) *(background(?:-color)?|color): *#?([a-fA-F0-9]{6}) *(?=$|;)/
+      HighlightBackgroundColorRx = /^\.highlight +\.hll +{ *background(?:-color)?: *#(\h{6})/
+      ColorPropertiesRx = /(?:^|;) *(background(?:-color)?|color): *#?(\h{6}) *(?=$|;)/
 
       @cache = ::Hash.new do |cache, key|
         styles = {}

--- a/lib/asciidoctor/pdf/formatted_text/parser.rb
+++ b/lib/asciidoctor/pdf/formatted_text/parser.rb
@@ -1002,11 +1002,11 @@ module Markup
 
     s0, i0 = [], index
     loop do
-      if has_terminal?(@regexps[gr = '\A[0-9A-Fa-f]'] ||= Regexp.new(gr), :regexp, index)
+      if has_terminal?(@regexps[gr = '\A[0-9a-fA-F]'] ||= Regexp.new(gr), :regexp, index)
         r1 = true
         @index += 1
       else
-        terminal_parse_failure('[0-9A-Fa-f]')
+        terminal_parse_failure('[0-9a-fA-F]')
         r1 = nil
       end
       if r1

--- a/lib/asciidoctor/pdf/formatted_text/parser.rb
+++ b/lib/asciidoctor/pdf/formatted_text/parser.rb
@@ -1002,11 +1002,11 @@ module Markup
 
     s0, i0 = [], index
     loop do
-      if has_terminal?(@regexps[gr = '\A[0-9a-f]'] ||= Regexp.new(gr), :regexp, index)
+      if has_terminal?(@regexps[gr = '\A[0-9A-Fa-f]'] ||= Regexp.new(gr), :regexp, index)
         r1 = true
         @index += 1
       else
-        terminal_parse_failure('[0-9a-f]')
+        terminal_parse_failure('[0-9A-Fa-f]')
         r1 = nil
       end
       if r1

--- a/lib/asciidoctor/pdf/formatted_text/parser.treetop
+++ b/lib/asciidoctor/pdf/formatted_text/parser.treetop
@@ -113,7 +113,7 @@ grammar Markup
   end
 
   rule character_hex
-    [0-9A-Fa-f] 2..5
+    [0-9a-fA-F] 2..5
   end
 
   rule character_name

--- a/lib/asciidoctor/pdf/formatted_text/parser.treetop
+++ b/lib/asciidoctor/pdf/formatted_text/parser.treetop
@@ -113,7 +113,7 @@ grammar Markup
   end
 
   rule character_hex
-    [0-9a-f] 2..5
+    [0-9A-Fa-f] 2..5
   end
 
   rule character_name

--- a/lib/asciidoctor/pdf/formatted_text/transform.rb
+++ b/lib/asciidoctor/pdf/formatted_text/transform.rb
@@ -7,7 +7,7 @@ module Asciidoctor
         LF = ?\n
         ZeroWidthSpace = ?\u200b
         CharEntityTable = { amp: '&', apos: ?', gt: '>', lt: '<', nbsp: ?\u00a0, quot: '"' }
-        CharRefRx = /&(?:(#{CharEntityTable.keys.join '|'})|#(?:(\d\d\d{0,4})|x([a-f\d][a-f\d][a-f\d]{0,3})));/
+        CharRefRx = /&(?:(#{CharEntityTable.keys.join '|'})|#(?:(\d{2,6})|x(\h{2,5})));/
         HexColorRx = /^#[a-fA-F0-9]{3,6}$/
         TextDecorationTable = { 'underline' => :underline, 'line-through' => :strikethrough }
         ThemeKeyToFragmentProperty = {

--- a/lib/asciidoctor/pdf/formatted_text/transform.rb
+++ b/lib/asciidoctor/pdf/formatted_text/transform.rb
@@ -7,8 +7,8 @@ module Asciidoctor
         LF = ?\n
         ZeroWidthSpace = ?\u200b
         CharEntityTable = { amp: '&', apos: ?', gt: '>', lt: '<', nbsp: ?\u00a0, quot: '"' }
-        CharRefRx = /&(?:(#{CharEntityTable.keys.join '|'})|#(?:(\d{2,6})|x(\h{2,5})));/
-        HexColorRx = /^#[a-fA-F0-9]{3,6}$/
+        CharRefRx = /&(?:(#{CharEntityTable.keys.join '|'})|#(?:(\d\d\d{0,4})|x(\h\h\h{0,3})));/
+        HexColorRx = /^#\h\h\h\h{0,3}$/
         TextDecorationTable = { 'underline' => :underline, 'line-through' => :strikethrough }
         ThemeKeyToFragmentProperty = {
           'background_color' => :background_color,

--- a/lib/asciidoctor/pdf/sanitizer.rb
+++ b/lib/asciidoctor/pdf/sanitizer.rb
@@ -20,8 +20,8 @@ module Asciidoctor
         'quot' => '"',
       }).default = '?'
       SanitizeXMLRx = /<[^>]+>/
-      CharRefRx = /&(?:amp;)?(?:([a-z][a-z]+\d{0,2})|#(?:(\d\d\d{0,4})|x([a-f\d][a-f\d][a-f\d]{0,3})));/
-      UnescapedAmpersandRx = /&(?!(?:[a-z][a-z]+\d{0,2}|#(?:\d\d\d{0,4}|x[a-f\d][a-f\d][a-f\d]{0,3}));)/
+      CharRefRx = /&(?:amp;)?(?:([a-z][a-z]+\d{0,2})|#(?:(\d\d\d{0,4})|x(\h\h\h{0,3})));/
+      UnescapedAmpersandRx = /&(?!(?:[a-z][a-z]+\d{0,2}|#(?:\d\d\d{0,4}|x\h\h\h{0,3}));)/
 
       # Strip leading, trailing and repeating whitespace, remove XML tags and
       # resolve all entities in the specified string.

--- a/lib/asciidoctor/pdf/theme_loader.rb
+++ b/lib/asciidoctor/pdf/theme_loader.rb
@@ -17,7 +17,7 @@ module Asciidoctor
 
       VariableRx = /\$([a-z0-9_-]+)/
       LoneVariableRx = /^\$([a-z0-9_-]+)$/
-      HexColorEntryRx = /^(?<k> *\p{Graph}+): +(?!null$)(?<q>["']?)(?<h>#)?(?<v>[a-fA-F0-9]{3,6})\k<q> *(?:#.*)?$/
+      HexColorEntryRx = /^(?<k> *\p{Graph}+): +(?!null$)(?<q>["']?)(?<h>#)?(?<v>\h\h\h\h{0,3})\k<q> *(?:#.*)?$/
       MultiplyDivideOpRx = %r((-?\d+(?:\.\d+)?) +([*/^]) +(-?\d+(?:\.\d+)?))
       AddSubtractOpRx = /(-?\d+(?:\.\d+)?) +([+\-]) +(-?\d+(?:\.\d+)?)/
       PrecisionFuncRx = /^(round|floor|ceil)\(/

--- a/spec/fixtures/glyph-font-test.adoc
+++ b/spec/fixtures/glyph-font-test.adoc
@@ -10,7 +10,7 @@ a--b `c--d`
 // ellipsis
 so... `well...`
 // euro sign
-99,99 &#x20ac; `-5,00 &#x20ac;`
+99,99 &#x20ac; `-5,00 &#x20AC;`
 // trademark sign
 YOLO&#x2122; `ACME&#x2122;`
 // math operators

--- a/spec/formatted_text_formatter_spec.rb
+++ b/spec/formatted_text_formatter_spec.rb
@@ -213,7 +213,7 @@ describe Asciidoctor::PDF::FormattedText::Formatter do
     end
 
     it 'should decode hexadecimal character references in link href' do
-      output = subject.format '<a href="https://cast.you?v=999999&#x26;list&#x3d;abcde&#x26;index&#x3d;1">My Playlist</a>'
+      output = subject.format '<a href="https://cast.you?v=999999&#x26;list=abcde&#x26;index=1">My Playlist</a>'
       (expect output).to have_size 1
       (expect output[0][:link]).to eql 'https://cast.you?v=999999&list=abcde&index=1'
     end

--- a/spec/formatted_text_formatter_spec.rb
+++ b/spec/formatted_text_formatter_spec.rb
@@ -183,6 +183,8 @@ describe Asciidoctor::PDF::FormattedText::Formatter do
         '&#x27;' => ?',
         '&#xa9;' => ?\u00a9,
         '&#x1f603;' => ([0x1f603].pack 'U1'),
+        '&#xA9;' => ?\u00a9,
+        '&#x1F603;' => ([0x1f603].pack 'U1'),
       }.each do |ref, chr|
         output = subject.format ref
         (expect output).to have_size 1

--- a/spec/formatted_text_formatter_spec.rb
+++ b/spec/formatted_text_formatter_spec.rb
@@ -213,7 +213,7 @@ describe Asciidoctor::PDF::FormattedText::Formatter do
     end
 
     it 'should decode hexadecimal character references in link href' do
-      output = subject.format '<a href="https://cast.you?v=999999&#x26;list=abcde&#x26;index=1">My Playlist</a>'
+      output = subject.format '<a href="https://cast.you?v=999999&#x26;list&#x3d;abcde&#x26;index&#x3d;1">My Playlist</a>'
       (expect output).to have_size 1
       (expect output[0][:link]).to eql 'https://cast.you?v=999999&list=abcde&index=1'
     end

--- a/spec/formatted_text_formatter_spec.rb
+++ b/spec/formatted_text_formatter_spec.rb
@@ -210,7 +210,7 @@ describe Asciidoctor::PDF::FormattedText::Formatter do
       (expect output[0][:link]).to eql 'https://cast.you?v=999999&list=abcde&index=1'
     end
 
-    it 'should decode hexidecimal character references in link href' do
+    it 'should decode hexadecimal character references in link href' do
       output = subject.format '<a href="https://cast.you?v=999999&#x26;list=abcde&#x26;index=1">My Playlist</a>'
       (expect output).to have_size 1
       (expect output[0][:link]).to eql 'https://cast.you?v=999999&list=abcde&index=1'

--- a/spec/outline_spec.rb
+++ b/spec/outline_spec.rb
@@ -670,13 +670,13 @@ describe 'Asciidoctor::PDF::Converter - Outline' do
       = ACME(TM) Catalog <&#8470;&nbsp;1>
       :doctype: book
 
-      == Paper Clips &#x2116;&nbsp;4
+      == Paper Clips &#x20Ac;&nbsp;4
       EOS
 
       outline = extract_outline pdf
       (expect outline).to have_size 2
       (expect outline[0][:title]).to eql %(ACME\u2122 Catalog <\u2116 1>)
-      (expect outline[1][:title]).to eql %(Paper Clips \u2116 4)
+      (expect outline[1][:title]).to eql %(Paper Clips \u20ac 4)
     end
   end
 end

--- a/spec/section_spec.rb
+++ b/spec/section_spec.rb
@@ -453,7 +453,7 @@ describe 'Asciidoctor::PDF::Converter - Section' do
     (expect underline[:from][:y]).to be_within(2).of(underlined_text[:y])
   end
 
-  it 'should support hexidecimal character reference in section title' do
+  it 'should support hexadecimal character reference in section title' do
     pdf = to_pdf <<~'EOS', analyze: true
     == &#xb5;Services
     EOS
@@ -477,7 +477,7 @@ describe 'Asciidoctor::PDF::Converter - Section' do
     (expect pdf.lines[0]).to eql 'ÜBER ÉTUDIER'
   end
 
-  it 'should ignore letters in hexidecimal character reference in section title when transforming to uppercase' do
+  it 'should ignore letters in hexadecimal character reference in section title when transforming to uppercase' do
     pdf = to_pdf <<~'EOS', pdf_theme: { heading_text_transform: 'uppercase' }, analyze: true
     == &#xb5;Services
     EOS


### PR DESCRIPTION
Issue #1990 created an extra filtering step in a process to change the case of hex characters.

Though I'm not well up to speed on Ruby, the contribution guidelines were quite clear, hence this PR :)

The commits
* make a failing test,
* adds a test for entities in hrefs (not sure about this one, **please check that this doesn't bork URI behavior**)
* update the parser to detect A-F also

`bundle exec rspec -fd spec/formatted_text_formatter_spec.rb`  reports all passing afterwards.