### PR TITLE
add border-style key to decorated block documentation

### DIFF
--- a/docs/modules/theme/pages/admonition.adoc
+++ b/docs/modules/theme/pages/admonition.adoc
@@ -11,22 +11,59 @@ The keys in the `admonition` category control the arrangement and style of admon
 |===
 |Key |Value Type |Example
 
-|column-rule-color
+|background-color
 |xref:color.adoc[Color] +
-(default: `'#eeeeee'`)
+(default: _not set_)
+|[source]
+admontition:
+  background-color: #757575
+
+|border-color
+|xref:color.adoc[Color] +
+(default: _not set_)
 |[source]
 admonition:
-  column-rule-color: '#aa0000'
+  border-color: #e6e8fa
+
+|border-radius
+|xref:measurement-units.adoc[Measurement] +
+(default: _not set_)
+|[source]
+admonition:
+  border-radius: 4
+
+|border-style
+|`dashed` {vbar} `dotted` {vbar} `double` {vbar} `solid`  {vbar} +
+(default: `solid`)
+|[source]
+admonition:
+  border-style: dashed
+
+|border-width
+|xref:measurement-units.adoc[Measurement] {vbar} xref:measurement-units.adoc[Measurement[ends,sides\]] +
+(default: _not set_)
+|[source]
+verse:
+  border-width: 0.5
+
+// TODO What about admonition_rule_color which is used on line 106 in the admonition_spec.rb?
+
+|column-rule-color
+|xref:color.adoc[Color] +
+(default: `'EEEEEE'`)
+|[source]
+admonition:
+  column-rule-color: #aa0000
 
 |column-rule-style
-|`solid` {vbar} `double` {vbar} `dashed` {vbar} `dotted` +
+|`dashed` {vbar} `dotted` {vbar} `double` {vbar} `solid`  {vbar} +
 (default: `solid`)
 |[source]
 admonition:
   column-rule-style: double
 
 |column-rule-width
-|xref:language.adoc#values[Number] +
+|xref:measurement-units.adoc[Measurement] +
 (default: `0.5`)
 |[source]
 admonition:
@@ -37,7 +74,7 @@ admonition:
 (default: _inherit_)
 |[source]
 admonition:
-  font-color: '#999999'
+  font-color: #999999
 
 |font-family
 |xref:font-support.adoc[Font family name] +
@@ -69,7 +106,7 @@ admonition:
 
 |padding
 |xref:measurement-units.adoc[Measurement] {vbar} xref:measurement-units.adoc[Measurement[top,right,bottom,left\]] +
-(default: `[0, 12, 0, 12]`)
+(default: `[4, 12, 4, 12]`)
 |[source]
 admonition:
   padding: [0, 14, 0, 14]
@@ -105,7 +142,7 @@ admonition:
 |[source]
 admonition:
   label:
-    font-color: '#262626'
+    font-color: #262626
 
 |font-family
 |xref:font-support.adoc[Font family name] +
@@ -148,7 +185,7 @@ admonition:
     min-width: 48
 
 |<<padding,padding>>
-|xref:measurement-units.adoc[Measurement] {vbar} xref:measurement-units.adoc[Measurement[top,right,bottom,left\]] +
+|xref:measurement-units.adoc[Measurement] {vbar} xref:measurement-units.adoc[Measurement[top(n/a),right,bottom(n/a),left\]] +
 (default: `$admonition-padding`)
 |[source]
 admonition:
@@ -194,7 +231,7 @@ The keys in the `admonition-label-<name>` category control the arrangement and s
 admonition:
   label:
     caution:
-      font-color: '#262626'
+      font-color: #262626
 
 |font-family
 |xref:font-support.adoc[Font family name] +
@@ -275,12 +312,12 @@ admonition:
 
 |stroke-color
 |xref:color.adoc[Color] +
-(default: caution=`'#bf3400'`; important=`'#bf0000'`; note=`'#19407c'`; tip=`'#111111'`; warning=`'#bf6900'`)
+(default: caution=`#bf3400`; important=`#bf0000`; note=`#19407c`; tip=`#111111`; warning=`#bf6900`)
 |[source]
 admonition:
   icon:
     important:
-      stroke-color: '#ff0000'
+      stroke-color: #ff0000
 |===
 
 [#name]

--- a/docs/modules/theme/pages/base.adoc
+++ b/docs/modules/theme/pages/base.adoc
@@ -23,13 +23,13 @@ base:
 
 |border-color
 |xref:color.adoc[Color] +
-(default: `'#eeeeee'`)
+(default: `'EEEEEE'`)
 |[source]
 base:
-  border-color: '#eeeeee'
+  border-color: #f0fff0
 
 |border-width
-|xref:language.adoc#values[Number] +
+|xref:measurement-units.adoc[Measurement] +
 (default: `0.5`)
 |[source]
 base:
@@ -37,10 +37,10 @@ base:
 
 |font-color
 |xref:color.adoc[Color] +
-(default: `'#000000'`)
+(default: `'000000'`)
 |[source]
 base:
-  font-color: '#333333'
+  font-color: #333333
 
 |font-family
 |xref:font-support.adoc[Font family name] +
@@ -94,7 +94,7 @@ base:
   line-height-length: 12
 
 |text-decoration-width
-|xref:language.adoc#values[Number] +
+|xref:measurement-units.adoc[Measurement] +
 (default: `1`)
 |[source]
 base:

--- a/docs/modules/theme/pages/block-image.adoc
+++ b/docs/modules/theme/pages/block-image.adoc
@@ -23,7 +23,7 @@ image:
 (default: _not set_)
 |[source]
 image:
-  border-color: '#cccccc'
+  border-color: #cccccc
 
 |<<fit,border-fit>>
 |`content` {vbar} `auto` +
@@ -33,14 +33,21 @@ image:
   border-fit: auto
 
 |border-radius
-|xref:language.adoc#values[Number] +
+|xref:measurement-units.adoc[Measurement] +
 (default: _not set_)
 |[source]
 image:
   border-radius: 2
 
+|border-style
+|`dashed` {vbar} `dotted` {vbar} `double` {vbar} `solid`
+(default: `solid`)
+|[source]
+image:
+  border-style: dashed
+
 |border-width
-|xref:language.adoc#values[Number] +
+|xref:measurement-units.adoc[Measurement] {vbar} xref:measurement-units.adoc[Measurement[ends,sides\]] +
 (default: _not set_)
 |[source]
 image:
@@ -95,7 +102,7 @@ image:
 |[source]
 image:
   alt:
-    font-color: '#ff000'
+    font-color: #ff0000
 
 |font-family
 |xref:font-support.adoc[Font family name] +

--- a/docs/modules/theme/pages/button.adoc
+++ b/docs/modules/theme/pages/button.adoc
@@ -16,14 +16,14 @@ The keys in the `button` category apply to a button reference generated from the
 (default: _not set_)
 |[source]
 button:
-  background-color: '#0000ff'
+  background-color: #0000ff
 
 |<<border-color,border-color>>
 |xref:color.adoc[Color] +
 (default: _not set_)
 |[source]
 button:
-  border-color: '#cccccc'
+  border-color: #cccccc
 
 |<<border-offset,border-offset>>
 |xref:language.adoc#values[Number] +
@@ -33,14 +33,14 @@ button:
   border-offset: 1.5
 
 |border-radius
-|xref:language.adoc#values[Number] +
+|xref:measurement-units.adoc[Measurement] +
 (default: `0`)
 |[source]
 button:
   border-radius: 2
 
 |border-width
-|xref:language.adoc#values[Number] +
+|xref:measurement-units.adoc[Measurement] +
 (default: `$base-border-width`)
 |[source]
 button:
@@ -58,7 +58,7 @@ button:
 (default: _inherit_)
 |[source]
 button:
-  font-color: '#ffffff'
+  font-color: #ffffff
 
 |font-family
 |xref:font-support.adoc[Font family name] +

--- a/docs/modules/theme/pages/code.adoc
+++ b/docs/modules/theme/pages/code.adoc
@@ -16,35 +16,42 @@ The keys in the `code` category control the arrangement and style of literal, li
 (default: _not set_)
 |[source]
 code:
-  background-color: '#f5f5f5'
+  background-color: #f5f5f5
 
 |border-color
 |xref:color.adoc[Color] +
-(default: `'#eeeeee'`)
+(default: `'EEEEEE'`)
 |[source]
 code:
-  border-color: '#cccccc'
+  border-color: #cccccc
 
 |border-radius
-|xref:language.adoc#values[Number] +
+|xref:measurement-units.adoc[Measurement] +
 (default: _not set_)
 |[source]
 code:
   border-radius: 4
 
+|border-style
+|`dashed` {vbar} `dotted` {vbar} `double` {vbar} `solid`
+(default: `solid`)
+|[source]
+code:
+  border-style: dashed
+
 |border-width
-|xref:language.adoc#values[Number] +
+|xref:measurement-units.adoc[Measurement] {vbar} xref:measurement-units.adoc[Measurement[ends,sides\]] +
 (default: `0.5`)
 |[source]
 code:
-  border-width: 0.75
+  border-width: [0.75, 0]
 
 |font-color
 |xref:color.adoc[Color] +
 (default: _inherit_)
 |[source]
 code:
-  font-color: '#333333'
+  font-color: #333333
 
 |font-family
 |xref:font-support.adoc[Font family name] +
@@ -106,10 +113,10 @@ Otherwise, the background color is controlled by the source highlighter theme.
 
 |background-color
 |xref:color.adoc[Color] +
-(default: `'#FFFFCC'`)
+(default: `#FFFFCC`)
 |[source]
 code:
-  highlight-background-color: '#ffff00'
+  highlight-background-color: #ffff00
 |===
 
 [#linenum]
@@ -124,9 +131,9 @@ Otherwise, the font color of line numbers are controlled by the source highlight
 
 |font-color
 |xref:color.adoc[Color] +
-(default: `'#999999'`)
+(default: `#999999`)
 |[source]
 code:
-  linenum-font-color: '#ccc'
+  linenum-font-color: #ccc
 |===
 

--- a/docs/modules/theme/pages/codespan.adoc
+++ b/docs/modules/theme/pages/codespan.adoc
@@ -16,14 +16,14 @@ The keys in the `codespan` category are used for inline monospace text in prose 
 (default: _not set_)
 |[source]
 codespan:
-  background-color: '#f5f5f5'
+  background-color: #f5f5f5
 
 |<<border-color,border-color>>
 |xref:color.adoc[Color] +
 (default: _not set_)
 |[source]
 codespan:
-  border-color: '#cccccc'
+  border-color: #cccccc
 
 |<<border-offset,border-offset>>
 |xref:language.adoc#values[Number] +
@@ -33,14 +33,14 @@ codespan:
   border-offset: 2
 
 |border-radius
-|xref:language.adoc#values[Number] +
+|xref:measurement-units.adoc[Measurement] +
 (default: _not set_)
 |[source]
 codespan:
   border-radius: 3
 
 |border-width
-|xref:language.adoc#values[Number] +
+|xref:measurement-units.adoc[Measurement] +
 (default: `$base-border-width`)
 |[source]
 codespan:
@@ -51,7 +51,7 @@ codespan:
 (default: _inherit_)
 |[source]
 codespan:
-  font-color: '#b12146'
+  font-color: #b12146
 
 |font-family
 |xref:font-support.adoc[Font family name] +

--- a/docs/modules/theme/pages/example.adoc
+++ b/docs/modules/theme/pages/example.adoc
@@ -10,27 +10,34 @@ The keys in the `example` category control the arrangement and style of example 
 
 |background-color
 |xref:color.adoc[Color] +
-(default: `'#ffffff'`)
+(default: `'FFFFFF'`)
 |[source]
 example:
-  background-color: '#fffef7'
+  background-color: #fffef7
 
 |border-color
 |xref:color.adoc[Color] +
-(default: `'#eeeeee'`)
+(default: `'EEEEEE'`)
 |[source]
 example:
-  border-color: '#eeeeee'
+  border-color: #191970
 
 |border-radius
-|xref:language.adoc#values[Number] +
+|xref:measurement-units.adoc[Measurement] +
 (default: _not set_)
 |[source]
 example:
   border-radius: 4
 
+|border-style
+|`dashed` {vbar} `dotted` {vbar} `double` {vbar} `solid` +
+(default: `solid`)
+|[source]
+example:
+  border-style: dashed
+
 |border-width
-|xref:language.adoc#values[Number] +
+|xref:measurement-units.adoc[Measurement] {vbar} xref:measurement-units.adoc[Measurement[ends,sides\]] +
 (default: `0.5`)
 |[source]
 example:
@@ -41,7 +48,7 @@ example:
 (default: _inherit_)
 |[source]
 example:
-  font-color: '#262626'
+  font-color: #262626
 
 |font-family
 |xref:font-support.adoc[Font family name] +
@@ -73,10 +80,10 @@ example:
 
 |padding
 |xref:measurement-units.adoc[Measurement] {vbar} xref:measurement-units.adoc[Measurement[top,right,bottom,left\]] +
-(default: `[12, 12, 0, 12]`)
+(default: `12`)
 |[source]
 example:
-  padding: [15, 15, 0, 15]
+  padding: [5, 10, 5, 10]
 
 |text-transform
 |xref:text.adoc#transform[Text transform] +

--- a/docs/modules/theme/pages/keyboard.adoc
+++ b/docs/modules/theme/pages/keyboard.adoc
@@ -17,14 +17,14 @@ The kbd reference is a span of text denoting textual user input from a keyboard,
 (default: _not set_)
 |[source]
 kbd:
-  background-color: '#fafafa'
+  background-color: #fafafa
 
 |<<border-color,border-color>>
 |xref:color.adoc[Color] +
 (default: _not set_)
 |[source]
 kbd:
-  border-color: '#cccccc'
+  border-color: #cccccc
 
 |<<offset,border-offset>>
 |xref:language.adoc#values[Number] +
@@ -34,14 +34,14 @@ kbd:
   border-offset: 1.5
 
 |<<border-color,border-radius>>
-|xref:language.adoc#values[Number] +
+|xref:measurement-units.adoc[Measurement] +
 (default: `0`)
 |[source]
 kbd:
   border-radius: 2
 
 |<<border-color,border-width>>
-|xref:language.adoc#values[Number] +
+|xref:measurement-units.adoc[Measurement] +
 (default: `$base-border-width`)
 |[source]
 kbd:
@@ -52,7 +52,7 @@ kbd:
 (default: _inherit_)
 |[source]
 kbd:
-  font-color: '#000'
+  font-color: #000
 
 |font-family
 |xref:font-support.adoc[Font family name] +

--- a/docs/modules/theme/pages/language.adoc
+++ b/docs/modules/theme/pages/language.adoc
@@ -48,8 +48,9 @@ The value of a key may be one of the following types:
 * Number (integer or float) with optional units (default unit is points)
 * Array
 ** Color as RGB array (e.g., [51, 51, 51])
-** Color CMYK array (e.g., [50, 100, 0, 0])
-** Margin (e.g., [1in, 1in, 1in, 1in])
+** Color as CMYK array (e.g., [50, 100, 0, 0])
+** Border width as ends and sides array (e.g., [10, 5])
+** Margin as top, right, bottom, and left array (e.g., [1in, 1in, 1in, 1in])
 ** Padding (e.g., [1in, 1in, 1in, 1in])
 * Variable reference (e.g., $base_font_color or $base-font-color)
 * Math expression
@@ -72,7 +73,7 @@ These keys may be written longhand:
 
 [source,yaml]
 ----
-base-font-color: '#333333'
+base-font-color: #333333
 base-font-family: Times-Roman
 base-font-size: 12
 ----
@@ -82,7 +83,7 @@ Or, to avoid having to type the prefix `base-` multiple times, the keys may be w
 [source,yaml]
 ----
 base:
-  font-color: '#333333'
+  font-color: #333333
   font-family: Times-Roman
   font-size: 12
 ----
@@ -93,7 +94,7 @@ Or even:
 ----
 base:
   font:
-    color: '#333333'
+    color: #333333
     family: Times-Roman
     size: 12
 ----

--- a/docs/modules/theme/pages/quote.adoc
+++ b/docs/modules/theme/pages/quote.adoc
@@ -16,24 +16,38 @@ The keys in the `quote` category control the arrangement and style of quote bloc
 (default: _not set_)
 |[source]
 quote:
-  background-color: '#dddddd'
+  background-color: #757575
 
 |border-color
 |xref:color.adoc[Color] +
-(default: `'#eeeeee'`)
+(default: `'EEEEEE'`)
 |[source]
 quote:
-  border-color: '#dddddd'
+  border-color: #e6e8fa
 
 |<<border-width,border-left-width>>
-|xref:language.adoc#values[Number] +
+|xref:measurement-units.adoc[Measurement] +
 (default: `4`)
 |[source]
 quote:
   border-left-width: 5
 
+|border-radius
+|xref:measurement-units.adoc[Measurement] +
+(default: _not set_)
+|[source]
+code:
+  border-radius: 4
+
+|border-style
+|`dashed` {vbar} `dotted` {vbar} `double` {vbar} `solid` +
+(default: `solid`)
+|[source]
+quote:
+  border-style: dotted
+
 |<<border-width,border-width>>
-|xref:language.adoc#values[Number] +
+|xref:measurement-units.adoc[Measurement] {vbar} xref:measurement-units.adoc[Measurement[ends,sides\]] +
 (default: `0`)
 |[source]
 quote:
@@ -44,7 +58,7 @@ quote:
 (default: _inherit_)
 |[source]
 quote:
-  font-color: '#333333'
+  font-color: #333333
 
 |font-family
 |xref:font-support.adoc[Font family name] +
@@ -76,10 +90,10 @@ quote:
 
 |padding
 |xref:measurement-units.adoc[Measurement] {vbar} xref:measurement-units.adoc[Measurement[top,right,bottom,left\]] +
-(default: `[6, 12, -6, 14]`)
+(default: `[6, 12, 6, 14]`)
 |[source]
 quote:
-  padding: [5, 10, -5, 12]
+  padding: [5, 10, 5, 10]
 
 |text-transform
 |xref:text.adoc#transform[Text transform] +
@@ -118,7 +132,7 @@ quote:
 |[source]
 quote:
   cite:
-    font-color: '#999999'
+    font-color: #999999
 
 |font-family
 |xref:font-support.adoc[Font family name] +

--- a/docs/modules/theme/pages/running-content.adoc
+++ b/docs/modules/theme/pages/running-content.adoc
@@ -28,7 +28,7 @@ IMPORTANT: If you don't specify a `height` for either the `header` or `footer` k
 (default: _not set_)
 |[source]
 header:
-  background-color: '#eeeeee'
+  background-color: #eeeeee
 
 |background-image
 |image macro +
@@ -42,17 +42,17 @@ header:
 (default: _not set_)
 |[source]
 header:
-border-color: '#dddddd'
+  border-color: #dddddd
 
 |border-style
-|`solid` {vbar} `double` {vbar} `dashed` {vbar} `dotted` +
+|`dashed` {vbar} `dotted` {vbar} `double` {vbar} `solid` +
 (default: `solid`)
 |[source]
 header:
   border-style: dashed
 
 |border-width
-|xref:measurement-units.adoc[Measurement] +
+|xref:measurement-units.adoc[Measurement] {vbar} xref:measurement-units.adoc[Measurement[ends,sides\]] +
 (default: `$base-border-width`)
 |[source]
 header:
@@ -63,7 +63,7 @@ header:
 (default: _not set_)
 |[source]
 header:
-  column-rule-color: '#CCCCCC'
+  column-rule-color: #CCCCCC
 
 |column-rule-spacing
 |xref:measurement-units.adoc[Measurement] +
@@ -73,7 +73,7 @@ header:
   column-rule-spacing: 5
 
 |column-rule-style
-|`solid` {vbar} `double` {vbar} `dashed` {vbar} `dotted` +
+|`dashed` {vbar} `dotted` {vbar} `double` {vbar} `solid` +
 (default: `solid`)
 |[source]
 header:
@@ -95,7 +95,7 @@ header:
 
 |content-margin
 |xref:measurement-units.adoc[Measurement] {vbar} xref:measurement-units.adoc[Measurement[top,right,bottom,left\]] +
-(default: [`0`, `inherit`])
+(default: `[0, inherit]`)
 |[source]
 header:
   content-margin: 0
@@ -105,7 +105,7 @@ header:
 (default: _inherit_)
 |[source]
 header:
-  font-color: '#333333'
+  font-color: #333333
 
 |font-family
 |xref:font-support.adoc[Font family name] +
@@ -157,7 +157,7 @@ header:
   line-height: 1.2
 
 |margin
-|xref:measurement-units.adoc[Measurement] {vbar} xref:measurement-units.adoc[Measurement[top,right,bottom (n/a),left\]] +
+|xref:measurement-units.adoc[Measurement] {vbar} xref:measurement-units.adoc[Measurement[top,right,bottom(n/a),left\]] +
 (default: [`0`, `inherit`])
 |[source]
 header:
@@ -215,7 +215,7 @@ header:
     content-margin: [0, 0, 0, inherit]
 
 |<<side,<side>-margin>>
-|xref:measurement-units.adoc[Measurement] {vbar} xref:measurement-units.adoc[Measurement[top,right,bottom (n/a),left\]] +
+|xref:measurement-units.adoc[Measurement] {vbar} xref:measurement-units.adoc[Measurement[top,right,bottom(n/a),left\]] +
 (default: _inherit_)
 |[source]
 header:
@@ -232,7 +232,7 @@ header:
 
 |<<position,<side>-<position>-content>>
 |xref:quoted-string.adoc[Quoted string] +
-(default: '\{page-number}')
+(default: `'\{page-number}'`)
 |[source]
 header:
   recto:
@@ -256,7 +256,7 @@ IMPORTANT: If you don't specify a `height` for either the `header` or `footer` k
 (default: _not set_)
 |[source]
 footer:
-  background-color: '#eeeeee'
+  background-color: #eeeeee
 
 |background-image
 |image macro +
@@ -270,17 +270,17 @@ footer:
 (default: _not set_)
 |[source]
 footer:
-  border-color: '#dddddd'
+  border-color: #dddddd
 
 |border-style
-|`solid` {vbar} `double` {vbar} `dashed` {vbar} `dotted` +
+|`dashed` {vbar} `dotted` {vbar} `double` {vbar} `solid` +
 (default: `solid`)
 |[source]
 footer:
   border-style: dashed
 
 |border-width
-|xref:measurement-units.adoc[Measurement] +
+|xref:measurement-units.adoc[Measurement] {vbar} xref:measurement-units.adoc[Measurement[ends,sides\]] +
 (default: `$base-border-width`)
 |[source]
 footer:
@@ -291,7 +291,7 @@ footer:
 (default: _not set_)
 |[source]
 footer:
-  column-rule-color: '#CCCCCC'
+  column-rule-color: #CCCCCC
 
 |column-rule-spacing
 |xref:measurement-units.adoc[Measurement] +
@@ -301,12 +301,13 @@ footer:
   column-rule-spacing: 5
 
 |column-rule-style
-|`solid` {vbar} `double` {vbar} `dashed` {vbar} `dotted` +
+|`dashed` {vbar} `dotted` {vbar} `double` {vbar} `solid` +
 (default: `solid`)
 |[source]
 footer:
   column-rule-style: dashed
 
+// TODO Since column-rule-style follows the pattern of border-style, does that mean column-rule-width follows the pattern of border-width?
 |column-rule-width
 |xref:measurement-units.adoc[Measurement] +
 (default: _not set_)
@@ -333,7 +334,7 @@ footer:
 (default: _inherit_)
 |[source]
 footer:
-  font-color: '#333333'
+  font-color: #333333
 
 |font-family
 |xref:font-support.adoc[Font family name] +
@@ -385,8 +386,8 @@ footer:
   line-height: 1.2
 
 |margin
-|xref:measurement-units.adoc[Measurement] {vbar} xref:measurement-units.adoc[Measurement[top (n/a),right,bottom,left\]] +
-(default: [`0`, `inherit`])
+|xref:measurement-units.adoc[Measurement] {vbar} xref:measurement-units.adoc[Measurement[top(n/a),right,bottom,left\]] +
+(default: `[0, inherit]`)
 |[source]
 footer:
   margin: 0

--- a/docs/modules/theme/pages/sidebar.adoc
+++ b/docs/modules/theme/pages/sidebar.adoc
@@ -13,27 +13,34 @@ The keys in the `sidebar` category control the arrangement and style of sidebar 
 
 |background-color
 |xref:color.adoc[Color] +
-(default: `'#eeeeee'`)
+(default: `'EEEEEE'`)
 |[source]
 sidebar:
-  background-color: '#eeeeee'
+  background-color: #121212
 
 |border-color
 |xref:color.adoc[Color] +
 (default: _not set_)
 |[source]
 sidebar:
-  border-color: '#ffffff'
+  border-color: #ffffff
 
 |border-radius
-|xref:language.adoc#values[Number] +
+|xref:measurement-units.adoc[Measurement] +
 (default: _not set_)
 |[source]
 sidebar:
   border-radius: 4
 
+|border-style
+|`dashed` {vbar} `dotted` {vbar} `double` {vbar} `solid` +
+(default: `solid`)
+|[source]
+sidebar:
+  border-style: dashed
+
 |border-width
-|xref:language.adoc#values[Number] +
+|xref:measurement-units.adoc[Measurement] {vbar} xref:measurement-units.adoc[Measurement[ends,sides\]] +
 (default: _not set_)
 |[source]
 sidebar:
@@ -44,7 +51,7 @@ sidebar:
 (default: _inherit_)
 |[source]
 sidebar:
-  font-color: '#262626'
+  font-color: #262626
 
 |font-family
 |xref:font-support.adoc[Font family name] +
@@ -54,7 +61,7 @@ sidebar:
   font-family: M+ 1p
 
 |font-kerning
-|normal {vbar} none +
+|`normal` {vbar} `none` +
 (default: _inherit_)
 |[source]
 sidebar:
@@ -76,7 +83,7 @@ sidebar:
 
 |padding
 |xref:measurement-units.adoc[Measurement] {vbar} xref:measurement-units.adoc[Measurement[top,right,bottom,left\]] +
-(default: `[12, 12, 0, 12]`)
+(default: `12`)
 |[source]
 sidebar:
   padding: [12, 15, 0, 15]
@@ -104,7 +111,7 @@ The keys in the `sidebar-title` category control the arrangement and style of si
 |[source]
 sidebar:
   title:
-    align: center
+    align: left
 
 |font-color
 |xref:color.adoc[Color] +
@@ -112,7 +119,7 @@ sidebar:
 |[source]
 sidebar:
   title:
-    font-color: '#333333'
+    font-color: #333333
 
 |font-family
 |xref:font-support.adoc[Font family name] +
@@ -123,7 +130,7 @@ sidebar:
     font-family: Noto Serif
 
 |font-kerning
-|normal {vbar} none +
+|`normal` {vbar} `none` +
 (default: _inherit_)
 |[source]
 sidebar:
@@ -144,7 +151,7 @@ sidebar:
 |[source]
 sidebar:
   title:
-    font-style: bold
+    font-style: bold_italic
 
 |text-transform
 |xref:text.adoc#transform[Text transform] +
@@ -152,5 +159,5 @@ sidebar:
 |[source]
 sidebar:
   title:
-    text-transform: uppercase
+    text-transform: capitalize
 |===

--- a/docs/modules/theme/pages/table.adoc
+++ b/docs/modules/theme/pages/table.adoc
@@ -14,6 +14,7 @@ The keys in the `table` category control the arrangement and style of tables and
 |background-color
 |xref:color.adoc[Color] +
 (default: `transparent`)
+//TODO Where is the transparent value for the table background set in the base theme?
 |[source]
 table:
   background-color: #ffffff
@@ -26,14 +27,14 @@ table:
   border-color: #dddddd
 
 |border-style
-|`solid` {vbar} `dashed` {vbar} `dotted` {vbar} Style[top,right,bottom,left] +
+|`dashed` {vbar} `dotted` {vbar} `solid` {vbar} Style[top,right,bottom,left] +
 (default: `solid`)
 |[source]
 table:
-  border-style: solid
+  border-style: [solid, ~, solid, dotted]
 
 |border-width
-|xref:language.adoc#values[Number] {vbar} xref:language.adoc#values[Number[top,right,bottom,left\]] +
+|xref:measurement-units.adoc[Measurement] {vbar} xref:measurement-units.adoc[Measurement[top,right,bottom,left\]] +
 (default: `0.5`)
 |[source]
 table:
@@ -73,7 +74,7 @@ table:
 (default: _inherit_)
 |[source]
 table:
-  font-color: '#333333'
+  font-color: #333333
 
 |font-family
 |xref:font-support.adoc[Font family name] +
@@ -118,7 +119,7 @@ table:
   grid-style: dashed
 
 |grid-width
-|xref:language.adoc#values[Number] {vbar} xref:language.adoc#values[Number[rows,cols\]] +
+|xref:measurement-units.adoc[Measurement] {vbar} xref:measurement-units.adoc[Measurement[rows,cols\]] +
 (default: `0.5`)
 |[source]
 table:
@@ -140,7 +141,7 @@ The keys in the `table-head` category control the arrangement and style of the t
 |[source]
 table:
   head:
-    background-color: '#f0f0f0'
+    background-color: #f0f0f0
 
 |border-bottom-color
 |xref:color.adoc[Color] +
@@ -148,10 +149,10 @@ table:
 |[source]
 table:
   head:
-    border-bottom-color: '#dddddd'
+    border-bottom-color: #dddddd
 
 |border-bottom-style
-|`solid` {vbar} `dashed` {vbar} `dotted` +
+|`dashed` {vbar} `dotted` {vbar} `solid` +
 (default: `solid`)
 |[source]
 table:
@@ -159,7 +160,7 @@ table:
     border-bottom-style: dashed
 
 |border-bottom-width
-|xref:language.adoc#values[Number] +
+|xref:measurement-units.adoc[Measurement] +
 (default: `1.25`)
 |[source]
 table:
@@ -172,7 +173,7 @@ table:
 |[source]
 table:
   head:
-    font-color: '#333333'
+    font-color: #333333
 
 |font-family
 |xref:font-support.adoc[Font family name] +
@@ -246,15 +247,15 @@ The keys in the `table-body` category control the background of the table body.
 |[source]
 table:
   body:
-    background-color: '#fdfdfd'
+    background-color: #fdfdfd
 
 |<<stripes,stripe-background-color>>
 |xref:color.adoc[Color] +
-(default: `'#eeeeee'`)
+(default: `'EEEEEE'`)
 |[source]
 table:
   body:
-    stripe-background-color: '#efefef'
+    stripe-background-color: #efefef
 |===
 
 [#stripes]
@@ -281,7 +282,7 @@ The keys in the `table-foot` category control the arrangement and style of the t
 |[source]
 table:
   foot:
-    background-color: '#f0f0f0'
+    background-color: #f0f0f0
 
 |font-color
 |xref:color.adoc[Color] +
@@ -289,7 +290,7 @@ table:
 |[source]
 table:
   foot:
-    font-color: '#333333'
+    font-color: #333333
 
 |font-family
 |xref:font-support.adoc[Font family name] +
@@ -375,7 +376,7 @@ The keys in the `table-header-cell` category control the style and arrangement o
 |[source]
 table:
   header-cell:
-    background-color: '#f0f0f0'
+    background-color: #f0f0f0
 
 |font-color
 |xref:color.adoc[Color] +
@@ -383,7 +384,7 @@ table:
 |[source]
 table:
   header-cell:
-    font-color: '#1a1a1a'
+    font-color: #1a1a1a
 
 |font-family
 |xref:font-support.adoc[Font family name] +

--- a/docs/modules/theme/pages/thematic-break.adoc
+++ b/docs/modules/theme/pages/thematic-break.adoc
@@ -10,13 +10,13 @@ The keys in the `thematic-break` category control the style of thematic breaks, 
 
 |border-color
 |xref:color.adoc[Color] +
-(default: `'#eeeeee'`)
+(default: `'EEEEEE'`)
 |[source]
 thematic-break:
-  border-color: '#eeeeee'
+  border-color: #e6e8fa
 
 |border-style
-|`solid` {vbar} `double` {vbar} `dashed` {vbar} `dotted` +
+|`dashed` {vbar} `dotted` {vbar} `double` {vbar} `solid` +
 (default: `solid`)
 |[source]
 thematic-break:
@@ -27,7 +27,7 @@ thematic-break:
 (default: `0.5`)
 |[source]
 thematic-break:
-  border-width: 0.5
+  border-width: 0.8
 
 |margin-bottom
 |xref:measurement-units.adoc[Measurement] +

--- a/docs/modules/theme/pages/verse.adoc
+++ b/docs/modules/theme/pages/verse.adoc
@@ -16,24 +16,38 @@ The keys in the `verse` category control the arrangement and style of verse bloc
 (default: _not set_)
 |[source]
 verse:
-  background-color: '#dddddd'
+  background-color: #757575
 
 |border-color
 |xref:color.adoc[Color] +
-(default: `'#eeeeee'`)
+(default: `'EEEEEE'`)
 |[source]
 verse:
-  border-color: '#dddddd'
+  border-color: #e6e8fa
 
 |<<border-width,border-left-width>>
-|xref:language.adoc#values[Number] +
+|xref:measurement-units.adoc[Measurement] +
 (default: `4`)
 |[source]
 verse:
   border-left-width: 5
 
+|border-radius
+|xref:measurement-units.adoc[Measurement] +
+(default: _not set_)
+|[source]
+code:
+  border-radius: 4
+
+|border-style
+|`dashed` {vbar} `dotted` {vbar} `double` {vbar} `solid`  {vbar} +
+(default: `solid`)
+|[source]
+verse:
+  border-style: dashed
+
 |<<border-width,border-width>>
-|xref:language.adoc#values[Number] +
+|xref:measurement-units.adoc[Measurement] {vbar} xref:measurement-units.adoc[Measurement[ends,sides\]] +
 (default: `0`)
 |[source]
 verse:
@@ -44,7 +58,7 @@ verse:
 (default: _inherit_)
 |[source]
 verse:
-  font-color: '#333333'
+  font-color: #333333
 
 |<<font-family,font-family>>
 |xref:font-support.adoc[Font family name] +
@@ -76,10 +90,10 @@ verse:
 
 |padding
 |xref:measurement-units.adoc[Measurement] {vbar} xref:measurement-units.adoc[Measurement[top,right,bottom,left\]] +
-(default: `[6, 12, -6, 14]`)
+(default: `[6, 12, 6, 14]`)
 |[source]
 verse:
-  padding: [5, 10, -5, 12]
+  padding: 5
 
 |text-transform
 |xref:text.adoc#transform[Text transform] +
@@ -116,7 +130,7 @@ The keys in the `verse-cite` category control the arrangement and style of the c
 |[source]
 verse:
   cite:
-    font-color: '#999999'
+    font-color: #999999
 
 |font-family
 |xref:font-support.adoc[Font family name] +


### PR DESCRIPTION
- update border width value type in key tables
- add missing border radius key in key tables