### PR TITLE
use sensible fallbacks for table border color and width

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -27,6 +27,7 @@ Bug Fixes::
 * allow smallest ends or sides border width on block to be less than 1
 * cap border corners on block when width is defined using array (uniform or otherwise) (#2103)
 * fix crash in certain circumstances when theme does not define value for `base-border-width` key
+* use sensible fallbacks for table border color and width (retains backwards compatibility)
 
 == 2.0.0.alpha.2 (2022-04-29) - @mojavelinux
 

--- a/data/themes/base-theme.yml
+++ b/data/themes/base-theme.yml
@@ -101,7 +101,6 @@ sidebar_title_font_style: bold
 table_border_color: '000000'
 table_border_style: solid
 table_border_width: 0.5
-table_grid_width: 0.5
 table_cell_padding: 2
 table_head_font_style: bold
 table_head_border_bottom_width: 1.25

--- a/docs/modules/theme/pages/table.adoc
+++ b/docs/modules/theme/pages/table.adoc
@@ -119,7 +119,7 @@ table:
 
 |grid-width
 |xref:measurement-units.adoc[Measurement] {vbar} xref:measurement-units.adoc[Measurement[rows,cols\]] +
-(default: `0.5`)
+(default: `$table-border-width`)
 |[source]
 table:
   grid-width: 1

--- a/lib/asciidoctor/pdf/converter.rb
+++ b/lib/asciidoctor/pdf/converter.rb
@@ -461,6 +461,7 @@ module Asciidoctor
       end
 
       def prepare_theme theme
+        theme.base_border_color ||= '000000'
         theme.base_border_width ||= 0
         theme.base_font_color ||= '000000'
         theme.base_font_size ||= 12
@@ -478,6 +479,7 @@ module Asciidoctor
         theme.list_item_spacing ||= 0
         theme.description_list_term_spacing ||= 0
         theme.description_list_description_indent ||= 0
+        theme.table_border_width ||= 0.5
         theme.image_border_width ||= 0
         theme.code_linenum_font_color ||= '999999'
         theme.callout_list_margin_top_after_code ||= 0
@@ -2186,17 +2188,17 @@ module Asciidoctor
 
         rect_side_names = [:top, :right, :bottom, :left]
         grid_axis_names = [:rows, :cols]
-        border_color = (rect_side_names.zip expand_rect_values theme.table_border_color, (theme.base_border_color || 'transparent')).to_h
+        border_color = (rect_side_names.zip expand_rect_values theme.table_border_color, theme.base_border_color).to_h
         border_style = (rect_side_names.zip (expand_rect_values theme.table_border_style, :solid).map(&:to_sym)).to_h
-        border_width = (rect_side_names.zip expand_rect_values theme.table_border_width, 0).to_h
-        grid_color = (grid_axis_names.zip expand_grid_values (theme.table_grid_color || [border_color[:top], border_color[:left]]), 'transparent').to_h
+        border_width = (rect_side_names.zip expand_rect_values theme.table_border_width, theme.base_border_width).to_h
+        grid_color = (grid_axis_names.zip expand_grid_values (theme.table_grid_color || [border_color[:top], border_color[:left]]), theme.base_border_color).to_h
         grid_style = (grid_axis_names.zip (expand_grid_values (theme.table_grid_style || [border_style[:top], border_style[:left]]), :solid).map(&:to_sym)).to_h
-        grid_width = (grid_axis_names.zip expand_grid_values theme.table_grid_width, 0).to_h
+        grid_width = (grid_axis_names.zip expand_grid_values (theme.table_grid_width || [border_width[:top], border_width[:left]]), theme.base_border_width).to_h
 
         if table_header_size
           head_border_bottom_color = theme.table_head_border_bottom_color || grid_color[:rows]
           head_border_bottom_style = theme.table_head_border_bottom_style&.to_sym || grid_style[:rows]
-          head_border_bottom_width = theme.table_head_border_bottom_width || grid_width[:rows]
+          head_border_bottom_width = theme.table_head_border_bottom_width || (grid_width[:rows] * 2.5)
         end
 
         case (grid = node.attr 'grid', 'all', 'table-grid')


### PR DESCRIPTION
retains backwards compatibility