### PR TITLE
resolves #2097 allow extended converter to insert or filter toc entries by overriding get_entries_for_toc method

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -10,6 +10,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/main[co
 Enhancements::
 
 * allow entry for document in outline to be controlled using `outline-title` attribute (#1789)
+* allow extended converter to insert or filter toc entries by overriding `get_entries_for_toc` method (#2097)
 * add `asciidoctor/pdf/nopngmagick` script to unregister Gmagick handler for PNG images only (#1687)
 
 Bug Fixes::

--- a/lib/asciidoctor/pdf/converter.rb
+++ b/lib/asciidoctor/pdf/converter.rb
@@ -3167,6 +3167,10 @@ module Asciidoctor
         @toc_extent = extent
       end
 
+      def get_entries_for_toc node
+        node.sections
+      end
+
       # NOTE: num_front_matter_pages not used during a dry run
       def ink_toc doc, num_levels, toc_page_number, start_cursor, num_front_matter_pages = 0
         go_to_page toc_page_number unless (page_number == toc_page_number) || scratch?
@@ -3200,7 +3204,7 @@ module Asciidoctor
             }
           end
           theme_margin :toc, :top
-          ink_toc_level doc.sections, num_levels, dot_leader, num_front_matter_pages
+          ink_toc_level (get_entries_for_toc doc), num_levels, dot_leader, num_front_matter_pages
         end
         # NOTE: range must be calculated relative to toc_page_number; absolute page number in scratch document is arbitrary
         toc_page_numbers = (toc_page_number..(toc_page_number + (page_number - start_page_number)))
@@ -3279,7 +3283,7 @@ module Asciidoctor
             end
           end
           indent @theme.toc_indent do
-            ink_toc_level entry.sections, num_levels_for_entry, dot_leader, num_front_matter_pages
+            ink_toc_level (get_entries_for_toc entry), num_levels_for_entry, dot_leader, num_front_matter_pages
           end if num_levels_for_entry >= entry_level
         end
       end

--- a/lib/asciidoctor/pdf/ext/prawn/extensions.rb
+++ b/lib/asciidoctor/pdf/ext/prawn/extensions.rb
@@ -269,6 +269,20 @@ module Asciidoctor
         dest_xyz 0, page_height, nil, (page_num ? state.pages[page_num - 1] : page)
       end
 
+      # Gets the destination registered for the specified name. The return value
+      # matches that which was passed to the add_dest method.
+      #
+      def get_dest name, node = dests.data
+        node.children.each do |child|
+          if ::PDF::Core::NameTree::Value === child
+            return child.value.data if child.name == name
+          elsif (found = get_dest name, child)
+            return found
+          end
+        end
+        nil
+      end
+
       # Fonts
 
       # Registers a new custom font described in the data parameter


### PR DESCRIPTION
As part of this change, ink_toc_level was rewritten to work with any block entries instead of assuming they are sections.