### PR TITLE
resolves #2128 make allocate_toc method reusable

### DIFF
--- a/docs/modules/extend/examples/pdf-converter-chapter-toc.rb
+++ b/docs/modules/extend/examples/pdf-converter-chapter-toc.rb
@@ -16,11 +16,9 @@ class PDFConverterChapterTOC < (Asciidoctor::Converter.for 'pdf')
   def ink_chapter_title sect, title, opts
     super
     if ((doc = sect.document).attr? 'chapter-toc') && (levels = (doc.attr 'chapter-toclevels', 1).to_i + 1) > 1
-      old_toc_extent = @toc_extent
       theme_font :base do
         sect.set_attr 'pdf-toc-extent', (allocate_toc sect, levels, cursor, false)
       end
-      @toc_extent = old_toc_extent
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -352,6 +352,14 @@ RSpec.configure do |config|
     end
   end
 
+  def docs_dir
+    File.join __dir__, '..', 'docs'
+  end
+
+  def doc_file path
+    File.absolute_path path, docs_dir
+  end
+
   def examples_dir
     File.join __dir__, '..', 'examples'
   end


### PR DESCRIPTION
- don't assign toc_extent instance variable inside method
- remove workaround in chapter TOC example in docs
- test chapter TOC example in docs
- add docs_dir and doc_file helpers to test suite