### PR TITLE
resolves #2134 use base-border-color as default border color

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -15,6 +15,8 @@ Enhancements::
 * allow theme to configure which end the caption is placed for a block image (#2115)
 * add `Page#imported` method to mark page as imported (which suppresses running contennt)
 * add support for `smallcaps` text transform by replacing lowercase letters with small capital variants (#1192)
+* use `base-border-color` as default border color; control appearance of border using `border-width` value alone (#2134)
+* remove border colors in base theme so all border colors can be controlled using `base-border-color` when extending theme
 
 Bug Fixes::
 

--- a/data/themes/base-theme.yml
+++ b/data/themes/base-theme.yml
@@ -13,8 +13,7 @@ base_font_size: 12
 base_font_size_min: 6
 base_font_style: normal
 base_line_height: 1.15
-base_border_color: 'EEEEEE'
-base_border_width: 0.5
+base_border_color: '000000'
 role_lead_font_size: 13.5
 role_line-through_text_decoration: line-through
 role_underline_text_decoration: underline
@@ -65,43 +64,37 @@ abstract_line_height: 1.4
 abstract_padding: 0
 abstract_title_align: center
 abstract_title_font_style: bold
-admonition_column_rule_color: 'EEEEEE'
 admonition_column_rule_width: 0.5
 admonition_padding: [4, 12, 4, 12]
 admonition_label_font_style: bold
 admonition_label_text_transform: uppercase
-quote_border_color: 'EEEEEE'
 quote_border_left_width: 4
 quote_padding: [3, 12, 3, 14]
-verse_border_color: 'EEEEEE'
 verse_border_left_width: 4
 verse_padding: [3, 12, 3, 14]
 code_font_family: Courier
 code_font_size: 10.8
 code_line_height: 1.2
 code_padding: 9
-code_border_color: 'EEEEEE'
 code_border_width: 0.5
 conum_line_height: 1.15
 conum_glyphs: circled
 example_background_color: 'FFFFFF'
-example_border_color: 'EEEEEE'
 example_border_width: 0.5
 example_padding: 12
 image_align: left
 prose_margin_bottom: 12
 sidebar_background_color: 'EEEEEE'
+sidebar_border_width: 0.5
 sidebar_padding: 12
 sidebar_title_align: center
 sidebar_title_font_style: bold
-table_border_color: '000000'
 table_border_style: solid
 table_border_width: 0.5
 table_cell_padding: 2
 table_head_font_style: bold
 table_head_border_bottom_width: 1.25
 table_body_stripe_background_color: 'EEEEEE'
-thematic_break_border_color: 'EEEEEE'
 thematic_break_border_style: solid
 thematic_break_border_width: 0.5
 thematic_break_margin_bottom: 12

--- a/spec/admonition_spec.rb
+++ b/spec/admonition_spec.rb
@@ -1077,22 +1077,18 @@ describe 'Asciidoctor::PDF::Converter - Admonition' do
       end
     end
 
-    it 'should assign default width to column rule if key is not specified' do
+    it 'should not assign default width to column rule if key is not specified' do
       pdf_theme = {
         admonition_column_rule_color: '222222',
         admonition_column_rule_width: nil,
+        base_border_width: nil,
       }
       pdf = to_pdf <<~'EOS', pdf_theme: pdf_theme, analyze: :line
       TIP: You can use the theme to customize the color and width of the column rule.
       EOS
 
       lines = pdf.lines
-      (expect lines).to have_size 1
-      column_rule = lines[0]
-      (expect column_rule[:from][:x]).to eql column_rule[:to][:x]
-      (expect column_rule[:color]).to eql '222222'
-      (expect column_rule[:width]).to eql 0.5
-      (expect column_rule[:style]).to eql :solid
+      (expect lines).to be_empty
     end
 
     it 'should not fail if base border width is not set when using original theme' do
@@ -1134,7 +1130,7 @@ describe 'Asciidoctor::PDF::Converter - Admonition' do
       (expect column_rule2[:from][:x] - column_rule1[:from][:x]).to eql 2.0
     end
 
-    it 'should use base border width for column rule if column rule width is nil' do
+    it 'should not use base border width for column rule if column rule width is nil' do
       pdf_theme = {
         base_border_width: 2,
         admonition_column_rule_color: '222222',
@@ -1145,11 +1141,7 @@ describe 'Asciidoctor::PDF::Converter - Admonition' do
       EOS
 
       lines = pdf.lines
-      (expect lines).to have_size 1
-      column_rule = lines[0]
-      (expect column_rule[:from][:x]).to eql column_rule[:to][:x]
-      (expect column_rule[:color]).to eql '222222'
-      (expect column_rule[:width]).to eql 2
+      (expect lines).to be_empty
     end
 
     it 'should allow theme to add border', visual: true do
@@ -1233,8 +1225,8 @@ describe 'Asciidoctor::PDF::Converter - Admonition' do
       (expect (text_left - left).to_f).to eql 72.0
     end
 
-    it 'should allow theme to disable column rule by setting color to nil' do
-      pdf_theme = { admonition_column_rule_color: nil }
+    it 'should allow theme to disable column rule by setting width to 0' do
+      pdf_theme = { admonition_column_rule_width: 0 }
       pdf = to_pdf <<~'EOS', pdf_theme: pdf_theme, analyze: :line
       TIP: You can use the theme to add a background color.
       EOS

--- a/spec/converter_spec.rb
+++ b/spec/converter_spec.rb
@@ -348,6 +348,22 @@ describe Asciidoctor::PDF::Converter do
         (expect (pdf.page 1).text).to include 'Documentation Chronicles'
       end
 
+      it 'should allow all border colors to be set using base-border-color when extending base theme' do
+        [
+          %(****\ncontent\n****),
+          %(====\ncontent\n====),
+          %([cols=2*]\n|===\n|a|b\n|c|d\n|===),
+          %(____\ncontent\n____),
+          %([verse]\n____\ncontent\n____),
+          %(----\ncontent\n----),
+          '---',
+          'NOTE: content',
+        ].each do |input|
+          pdf = to_pdf input, pdf_theme: { extends: 'base', base_border_color: '0000EE' }, analyze: :line
+          (expect pdf.lines.map {|it| it[:color] }.uniq).to eql %w(0000EE)
+        end
+      end
+
       it 'should convert background position to options' do
         converter = Asciidoctor::Converter.create 'pdf'
         {

--- a/spec/example_spec.rb
+++ b/spec/example_spec.rb
@@ -313,7 +313,7 @@ describe 'Asciidoctor::PDF::Converter - Example' do
     lines = (to_pdf input, attribute_overrides: { 'pdf-theme' => 'base' }, analyze: :line).lines
 
     (expect lines).to have_size 4
-    (expect lines.map {|it| it[:color] }.uniq).to eql ['EEEEEE']
+    (expect lines.map {|it| it[:color] }.uniq).to eql %w(000000)
     (expect lines.map {|it| it[:width] }.uniq).to eql [0.5]
     top, bottom = lines.map {|it| [it[:from][:y], it[:to][:y]] }.flatten.yield_self {|it| [it.max, it.min] }
     left = lines.map {|it| [it[:from][:x], it[:to][:x]] }.flatten.min

--- a/spec/running_content_spec.rb
+++ b/spec/running_content_spec.rb
@@ -1494,12 +1494,12 @@ describe 'Asciidoctor::PDF::Converter - Running Content' do
       (expect to_file).to visually_match 'running-content-border-style.pdf'
     end
 
-    it 'should use base border width and solid style if border width and style are not specified', visual: true do
+    it 'should use base border color and solid style if border width and style are not specified', visual: true do
       pdf_theme = {
-        base_border_width: 1,
-        footer_border_width: nil,
+        base_border_color: '000000',
+        footer_border_color: nil,
+        footer_border_width: 1,
         footer_border_style: nil,
-        footer_border_color: '000000',
       }
 
       to_file = to_pdf_file 'content', 'running-content-border-defaults.pdf', enable_footer: true, pdf_theme: pdf_theme

--- a/spec/sidebar_spec.rb
+++ b/spec/sidebar_spec.rb
@@ -82,7 +82,7 @@ describe 'Asciidoctor::PDF::Converter - Sidebar' do
     boundaries = (pdf.extract_graphic_states pdf.pages[0][:raw_content])[0]
       .select {|l| l.end_with? 'l' }
       .map {|l| l.split.yield_self {|it| { x: it[0].to_f, y: it[1].to_f } } }
-    (expect boundaries).to have_size 4
+    (expect boundaries).to have_size 8 # border and background
     top, bottom = boundaries.map {|it| it[:y] }.yield_self {|it| [it.max, it.min] }
     left = boundaries.map {|it| it[:x] }.min
     text_top = (pdf.find_unique_text 'first').yield_self {|it| it[:y] + it[:font_size] }


### PR DESCRIPTION
* control appearance of border using border-width value
* if border-color for element is not set or nil, fall back to value of base-border-color
* don't set default value for base_border_color and base_border_width keys on theme object
* change fallback value for table border color to base-border-color
* change fallback value for thematic break stroke color to base-border-color
* don't use base-border-width as fallback width for admonition column rule
* interpret nil value in table border color array as transparent
* interpret nil value in table border width array as 0
* don't set border colors in base theme so they can be controlled using base-border-color when extending theme
* set border width on sidebar in base theme