### PR TITLE
resolves #2149 preserve columns on subsequent pages in the index section

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -16,6 +16,8 @@ Bug Fixes::
 
 * allow theme to set font style of first line of abstract to `normal_italic` (#2138)
 * add support for `:color` option to `Prawn::Text::Formatted::Box` directly and remove workarounds
+* preserve columns on subsequent pages in the index section (#2149)
+* fix return value of `cursor` method inside block for column box
 
 == 2.0.0.beta.1 (2022-05-04) - @mojavelinux
 

--- a/lib/asciidoctor/pdf/converter.rb
+++ b/lib/asciidoctor/pdf/converter.rb
@@ -2415,25 +2415,15 @@ module Asciidoctor
         space_needed_for_category = @theme.description_list_term_spacing + (2 * (height_of_typeset_text 'A'))
         pagenum_sequence_style = node.document.attr 'index-pagenum-sequence-style'
         column_box [0, cursor], columns: @theme.index_columns, width: bounds.width, reflow_margins: true do
-          def @bounding_box.move_past_bottom *args # rubocop:disable Lint/NestedMethodDefinition
-            super(*args)
-            @document.bounds = @parent = @document.margin_box if @current_column == 0 && @reflow_margins
-          end
           @index.categories.each do |category|
-            # NOTE: cursor method always returns 0 inside column_box; breaks reference_bounds.move_past_bottom
-            bounds.move_past_bottom if space_needed_for_category > y - reference_bounds.absolute_bottom
+            bounds.move_past_bottom if space_needed_for_category > cursor
             ink_prose category.name,
               align: :left,
               inline_format: false,
               margin_bottom: @theme.description_list_term_spacing,
               style: @theme.description_list_term_font_style&.to_sym
             category.terms.each {|term| convert_index_list_item term, pagenum_sequence_style }
-            # NOTE: see previous note for why we can't use margin_bottom method
-            if @theme.prose_margin_bottom > y - reference_bounds.absolute_bottom
-              bounds.move_past_bottom
-            else
-              move_down @theme.prose_margin_bottom
-            end
+            @theme.prose_margin_bottom > cursor ? bounds.move_past_bottom : (move_down @theme.prose_margin_bottom)
           end
         end
         nil

--- a/lib/asciidoctor/pdf/ext/prawn.rb
+++ b/lib/asciidoctor/pdf/ext/prawn.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # the following are organized under the Asciidoctor::Prawn namespace
+require_relative 'prawn/document/column_box'
 require_relative 'prawn/font_metric_cache'
 require_relative 'prawn/font/afm'
 require_relative 'prawn/images'

--- a/lib/asciidoctor/pdf/ext/prawn/document/column_box.rb
+++ b/lib/asciidoctor/pdf/ext/prawn/document/column_box.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+Prawn::Document::ColumnBox.prepend (Module.new do
+  def absolute_bottom
+    stretchy? ? @parent.absolute_bottom : super
+  end
+
+  def move_past_bottom *_args
+    initial_page = @document.page
+    super
+    if (page = @document.page) != initial_page && page.margins != initial_page.margins
+      @document.bounds = self.class.new @document, @parent, (margin_box = @document.margin_box).absolute_top_left,
+        columns: @columns, reflow_margins: true, spacer: @spacer, width: margin_box.width
+    end
+  end
+end)


### PR DESCRIPTION
- patch move_past_bottom method of ColumnBox to recompute bounds if page margin has changed
- fix return value of cursor method inside block for column box
- simplify checks for page available in index section