### PR TITLE
Docs reviewed with grammar and spell checker

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -662,7 +662,7 @@ image::custom-pages.pdf[page=2]
 
 You can import multiple pages either using multiple image macros or using the `pages` attribute.
 The `pages` attribute accepts individual page numbers or page number ranges (two page numbers separated by `..`).
-The values can be separated either by commas or semi-colons.
+The values can be separated either by commas or semicolons.
 (The syntax is similar to the syntax uses for the `lines` attribute of the AsciiDoc include directive).
 
 [source,asciidoc]

--- a/docs/modules/ROOT/pages/autowidth-tables.adoc
+++ b/docs/modules/ROOT/pages/autowidth-tables.adoc
@@ -15,7 +15,7 @@ As a result, columns which reported the width necessary to render without wrappi
 The reason this compression is not performed like in HTML is because prawn-table has no awareness of words.
 Thus, it doesn't know how to redistribute with width intelligently.
 
-To protected against truncation or insufficient width errors, prawn-table wraps text by character.
+To protect against truncation or insufficient width errors, prawn-table wraps text by character.
 That's why the last character in the cell can end up getting wrapped.
 (There's a small amount of tolerance built in to prawn-table to address some edge cases, but it's not sufficient to handle all of them).
 

--- a/docs/modules/ROOT/pages/breakable-and-unbreakable.adoc
+++ b/docs/modules/ROOT/pages/breakable-and-unbreakable.adoc
@@ -111,7 +111,7 @@ This logic is vital for decorating the block with a border and background becaus
 All these dry runs add additional processing time and effort to the conversion.
 
 Making all blocks unbreakable by default adds a lot of extra steps (not to mention leaving behind a lot of gaps in the document).
-Orphan prevents adds almost as many since its a similar process.
+Orphan prevents adds almost as many since it's a similar process.
 Doing that by default for tables and sections would be too complex and costly.
 To recoup some of the processing time, we decided to make some trade-offs.
 Therefore, blocks are breakable by default and authors must opt-in to get orphan prevention for tables and sections.

--- a/docs/modules/ROOT/pages/features.adoc
+++ b/docs/modules/ROOT/pages/features.adoc
@@ -39,7 +39,7 @@
 * Table cells that exceed the height of a single page are truncated with a warning (see https://github.com/prawnpdf/prawn-table/issues/41[prawn-table#41^]).
 * A column can't be assigned a `width` of `0%` or a `width` less than the width of a single character.
 The converter will skip the table and emit a warning if such a case occurs.
-* A column can't be set to `autowidth` if the width of all the other columns in the table meet or exceed 100%.
+* A column can't be set to `autowidth` if the width of all the other columns in the table meets or exceeds 100%.
 The converter will skip the table and emit a warning if such a case occurs.
 * An inline image in a table cell will shrink to fit (rather than force the column wider) if the width of the image exceeds the width of the column; you can increase the width of the column using `cols` or convert the cell to an AsciiDoc table cell and, preferably, use a block image (see {url-project-issues}/830[#830^]).
 * An inline image with a percentage `width` value in an `autowidth` table cell is resized relative to its intrinsic width.

--- a/docs/modules/ROOT/pages/index-catalog.adoc
+++ b/docs/modules/ROOT/pages/index-catalog.adoc
@@ -23,7 +23,7 @@ However, you could use an extension, such as a TreeProcessor, to automatically m
 == How index terms are grouped and sorted
 
 By default, the converter groups index terms by the first letter of the primary term (e.g., A), which we call the category.
-These categories are displayed in alphabetically order in the index.
+These categories are displayed in alphabetical order in the index.
 Within the category, the converter sorts the terms alphabetically.
 
 The exception to this rule is if the primary term does not start with a letter.

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -15,7 +15,7 @@ You are encouraged to migrate to Asciidoctor PDF 2 as soon as possible.
 == Overview
 
 Asciidoctor PDF converts an AsciiDoc document directly to a PDF document.
-The style and layout of the PDF is controlled by a dedicated theme file.
+The style and layout of the PDF are controlled by a dedicated theme file.
 To the degree possible, Asciidoctor PDF supports all the features of AsciiDoc that are supported by Asciidoctor.
 It also provides xref:features.adoc[additional PDF-specific features].
 However, there are xref:features.adoc#limitations[certain limits] imposed by the PDF format and the underlying PDF library this extension uses.

--- a/docs/modules/ROOT/pages/install.adoc
+++ b/docs/modules/ROOT/pages/install.adoc
@@ -114,12 +114,12 @@ To turn on automatic hyphenation using the `hyphens` attribute, you'll need to i
  $ gem install text-hyphen
 
 Accelerated image decoding::
-Ruby is not particularly fast at decoding images, and the image formats it supports is limited.
+Ruby is not particularly fast at decoding images, and the image formats it supports are limited.
 To help, you can install prawn-gmagick, which delegates the work of decoding images to GraphicsMagick.
 Refer to xref:image-paths-and-formats.adoc[Supporting additional image file formats] for instructions about how to enable this integration.
 
 The following table lists the optional dependencies of Asciidoctor PDF, including Asciidoctor extensions which are tested with this converter.
-The name of the dependency and its gem name is listed along with the minimum supported version and what feature or features it enables when installed (and, if necessary, required).
+The name of the dependency and its gem name are listed along with the minimum supported version and what feature or features it enables when installed (and, if necessary, required).
 
 [cols=3;3;4]
 |===

--- a/docs/modules/ROOT/pages/interdocument-xrefs.adoc
+++ b/docs/modules/ROOT/pages/interdocument-xrefs.adoc
@@ -93,7 +93,7 @@ We cover a little bit here.
 The rest you can find in <<chapters/chapter-2.adoc#_chapter_2,Chapter 2>>.
 ----
 
-And the contents of chapter 2 is as follows:
+And the contents of chapter 2 are as follows:
 
 [,asciidoc]
 ----
@@ -109,7 +109,7 @@ To begin, jump to <<chapters/chapter-2/first-steps.adoc#_first_steps,first steps
 \include::chapter-2/first-steps.adoc[]
 ----
 
-And, finally, the contents of the nested include is as follows:
+And, finally, the contents of the nested include are as follows:
 
 [,asciidoc]
 ----

--- a/docs/modules/ROOT/pages/optimize-pdf.adoc
+++ b/docs/modules/ROOT/pages/optimize-pdf.adoc
@@ -1,7 +1,7 @@
 = Optimize the PDF
 :url-hexapdf: https://hexapdf.gettalong.org/
 
-By default, Asciidoctor PDF does not optimize the PDF it generates or compress its streams.
+By default, Asciidoctor PDF does not optimize the PDF it generates or compresses its streams.
 This page covers several approaches you can take to optimize your PDF.
 
 IMPORTANT: If you're creating a PDF for Amazon's Kindle Direct Publishing (KDP), GitLab repository preview, or other online publishers, you'll likely need to optimize the file before uploading.
@@ -145,7 +145,7 @@ To see more options that `hexapdf optimize` offers, run:
 
  $ hexapdf help optimize
 
-For example, to make the source of the PDF a bit more readable (though less optimized), set the stream-related options to `preserve` (e.g.,, `--streams preserve` from the CLI or `options.streams = :preserve` from the API).
+For example, to make the source of the PDF a bit more readable (though less optimized), set the stream-related options to `preserve` (e.g., `--streams preserve` from the CLI or `options.streams = :preserve` from the API).
 You can also disable page compression (e.g., `--no-compress-pages` from the CLI or `options.compress_pages = false` from the API).
 
 hexapdf also allows you to add password protection to your PDF, if that's something you're interested in doing.

--- a/docs/modules/ROOT/pages/whats-new.adoc
+++ b/docs/modules/ROOT/pages/whats-new.adoc
@@ -126,7 +126,7 @@ The `table-caption-side` theme key has been xref:theme:tables.adoc#end[renamed t
 * The font size of a literal table cells and nested blocks in AsciiDoc table cells is now scaled.
 * AsciiDoc table cells inherit the font properties from the table.
 * The content of an AsciiDoc table cell is prevented from overrunning the footer or subsequent pages.
-* The top and bottom padding is taken into account when computing the height of AsciiDoc table cell.
+* The top and bottom padding is taken into account when computing the height of an AsciiDoc table cell.
 * An error message is logged if a table cell is truncated.
 * Instead of raising an error, the converter logs an error and skips the table if the content cannot fit within the designated width of a cell.
 
@@ -246,7 +246,7 @@ Integer page numbering can start at the front cover by assigning the keyword `co
 Or, you can have the page numbering start after the TOC, wherever the TOC is placed, by assigning `after-toc` to the `start-at` key.
 Alternatively, the theme can specify an offset from the first body page where the page numbering should begin when an integer is assigned to `start-at`.
 
-Margin and content margin:: The margin and content margin of the running content per per periphery (header or footer) and per side (recto or verso) can now be configured from the theme.
+Margin and content margin:: The margin and content margin of the running content per periphery (header or footer) and per side (recto or verso) can now be configured from the theme.
 The margins in running content can be specified using a 2-value array for ends and sides or 3-value array with implied left side value.
 
 Part and chapter numbers:: If the `partnums` attribute is set, the `part-numeral` attribute is automatically set in the running content.

--- a/docs/modules/extend/pages/use-cases.adoc
+++ b/docs/modules/extend/pages/use-cases.adoc
@@ -114,7 +114,7 @@ This functionality is already provided by the converter if you set the `breakabl
 The code is presented here both to explain how it works and to use to make this behavior automatic.
 
 If an in-flow heading is followed by content that doesn't fit on the current page, and the `breakable` option is not set on the heading, the converter will orphan the heading on the current page.
-You can fix this behavior by overridding the `arrange_heading` method in an extended converter.
+You can fix this behavior by overriding the `arrange_heading` method in an extended converter.
 
 This extended converter takes this opportunity to use `dry_run` to make an attempt to write content in the remaining space on the page after the heading.
 If no content is written, it advances to the next page before inking the heading (and its corresponding anchor).
@@ -157,7 +157,7 @@ include::example$pdf-converter-image-indent.rb[]
 
 The `indent` DSL method adds padding to either side of the content area, delegates to the specified code block, then shaves it back off.
 
-This converter works when a custom theme defines the `image-indent` key, as follow:
+This converter works when a custom theme defines the `image-indent` key, as follows:
 
 [,yaml]
 ----

--- a/docs/modules/extend/pages/use-converter.adoc
+++ b/docs/modules/extend/pages/use-converter.adoc
@@ -9,7 +9,7 @@ To use this converter, require it by passing the path to the `-r` flag when call
 
 The converter will self-register with the `pdf` backend and thus get used as the Asciidoctor PDF converter.
 
-That's all there is too it!
+That's all there is to it!
 
 == Go further
 

--- a/docs/modules/theme/pages/apply-theme.adoc
+++ b/docs/modules/theme/pages/apply-theme.adoc
@@ -18,7 +18,7 @@ If you use images in your theme, image paths are resolved relative to this direc
 If `pdf-theme` ends with `.yml`, and `pdf-themesdir` is not specified, then `pdf-themesdir` defaults to the directory of the path specified by `pdf-theme`.
 
 pdf-fontsdir:: The directory or directories where the fonts used by your theme, if any, are located.
-Multiple entries must be separated by either a comma or a semi-colon.
+Multiple entries must be separated by either a comma or a semicolon.
 To reference a file inside a JAR file on the classpath, prefix with the path with `uri:classloader:` (AsciidoctorJ only).
 _Specifying an absolute path is recommended._
 
@@ -54,7 +54,7 @@ However, in this case, image paths in your theme won't be resolved properly.
 
 Paths are resolved relative to the current directory.
 However, in the future, this may change so that paths are resolved relative to the base directory (typically the document's directory).
-Therefore, it's recommend that you specify absolute paths for now to future-proof your configuration.
+Therefore, it's recommended that you specify absolute paths for now to future-proof your configuration.
 
  $ asciidoctor-pdf -a pdf-themesdir=/path/to/resources/themes -a pdf-theme=basic -a pdf-fontsdir=/path/to/resources/fonts
 

--- a/docs/modules/theme/pages/block-images.adoc
+++ b/docs/modules/theme/pages/block-images.adoc
@@ -3,7 +3,7 @@
 
 In general, the xref:blocks.adoc[] apply to block images and their captions.
 You can further customize how the block images, alt text, and captions are arranged and styled using the xref:block-image.adoc[].
-The following sections provide information and examples about the keys and values that are unique to the block images.
+The following sections provide information and examples of the keys and values that are unique to the block images.
 
 [#caption-align]
 == Caption alignment

--- a/docs/modules/theme/pages/callout.adoc
+++ b/docs/modules/theme/pages/callout.adoc
@@ -91,7 +91,7 @@ callout-list:
 
 The keys in the `conum` category control the style of callout numbers inside verbatim blocks and in callout lists.
 These keys don't affect the callout list item content.
-The appearance of the callout list and the content of the list items is controlled independently by the keys in <<callout-list,callout-list category>>.
+The appearance of the callout list and the content of the list items are controlled independently by the keys in <<callout-list,callout-list category>>.
 Also see <<inherit>> for more information.
 
 [cols="2,5,5a"]

--- a/docs/modules/theme/pages/code.adoc
+++ b/docs/modules/theme/pages/code.adoc
@@ -124,7 +124,7 @@ code:
 == code-linenum
 
 The key in the `code-linenum` category only applies when you use Pygments as the source highlighter.
-Otherwise, the font color of line numbers are controlled by the source highlighter theme.
+Otherwise, the font color of line numbers is controlled by the source highlighter theme.
 
 [cols="2,4,6a"]
 |===

--- a/docs/modules/theme/pages/color.adoc
+++ b/docs/modules/theme/pages/color.adoc
@@ -56,7 +56,7 @@ Here's how to specify the color red in RGB:
 
 * [255, 0, 0]
 
-Here's how a RGB color value appears in the theme file:
+Here's how an RGB color value appears in the theme file:
 
 [,yaml]
 ----

--- a/docs/modules/theme/pages/custom-font.adoc
+++ b/docs/modules/theme/pages/custom-font.adoc
@@ -148,5 +148,5 @@ Effectively, it subsets the font.
 While that saves space taken up by the generated PDF, you may still be storing the full font in your source repository.
 
 To minimize the size of the source font, you can use {url-fontforge}[FontForge^] to subset the font ahead of time.
-Subsetting a font means remove glyphs you don't plan to use.
+Subsetting a font means removing glyphs you don't plan to use.
 Doing so is not a requirement, simply a personal preference.

--- a/docs/modules/theme/pages/font-support.adoc
+++ b/docs/modules/theme/pages/font-support.adoc
@@ -83,7 +83,7 @@ Asciidoctor PDF bundles several fonts that are used by the default theme or a fa
 You can also declare these fonts in your custom theme.
 These fonts provide more characters than the built-in PDF fonts, but still only a subset of UTF-8 (to reduce the size of the gem).
 
-The family name of the fonts bundled with Asciidoctor PDF are as follows:
+The family names of the fonts bundled with Asciidoctor PDF are as follows:
 
 {url-mplus-onemn}[M+ 1mn^]::
 A monospaced font that maps different thicknesses to the styles `normal`, `italic`, `bold`, and `bold_italic`.
@@ -129,4 +129,4 @@ Notice the `-a scripts=cjk` option.
 That's important.
 It tells the converter to insert break opportunities between CJK characters so that lines wrap properly when mixing English and a CJK language like Japanese.
 
-If the built-in theme with the fallback font doesn't go far enough, you'll need create a xref:cjk.adoc[custom CJK theme].
+If the built-in theme with the fallback font doesn't go far enough, you'll need to create a xref:cjk.adoc[custom CJK theme].

--- a/docs/modules/theme/pages/language.adoc
+++ b/docs/modules/theme/pages/language.adoc
@@ -108,7 +108,7 @@ Also note the presence of the colon (`:`) after each key name.
 
 == Inheritance
 
-Like CSS, inheritance is a principle feature in the Asciidoctor PDF theme language.
+Like CSS, inheritance is a principal feature in the Asciidoctor PDF theme language.
 For many of the properties, if a key is not specified, the key inherits the value applied to the parent content in the content hierarchy.
 This behavior saves you from having to specify properties unless you want to override the inherited value.
 

--- a/docs/modules/theme/pages/page-numbers.adoc
+++ b/docs/modules/theme/pages/page-numbers.adoc
@@ -95,7 +95,7 @@ See xref:add-running-content.adoc#page-number[Modify page number position] for a
 [#display]
 == Displaying the page numbers
 
-To adjust on what page the page numbers begin to be displayed on, you need change the page on which the running content starts.
+To adjust on what page the page numbers begin to be displayed on, you need to change the page on which the running content starts.
 This is controlled by the xref:add-running-content.adoc#start-at[running-content-start-at key].
 For example, to start the running content on the title page, assuming the title page is enabled, set `running-content-start-at: title` in your theme file.
 To learn more about customizing the running content, see xref:add-running-content.adoc[].

--- a/docs/modules/theme/pages/source-highlighting-theme.adoc
+++ b/docs/modules/theme/pages/source-highlighting-theme.adoc
@@ -77,7 +77,7 @@ Use the `Text` token to set the background color of the source block and the def
 The complete list of tokens can be found in the {url-jneen-rouge}/blob/master/lib/rouge/token.rb[token.rb file^] from Rouge.
 Refer to the {url-jneen-rouge}/tree/master/lib/rouge/themes[bundled themes^] to find more examples.
 
-Once you've defined your theme, you need to enable it use it using the `rouge-style` document attribute, which you specify in the document header or via the Asciidoctor CLI or API.
+Once you've defined your theme, you need to enable it to use it using the `rouge-style` document attribute, which you specify in the document header or via the Asciidoctor CLI or API.
 
 [,asciidoc]
 ----

--- a/docs/modules/theme/pages/table.adoc
+++ b/docs/modules/theme/pages/table.adoc
@@ -108,8 +108,8 @@ table:
 == table-head
 
 The keys in the `table-head` category control the arrangement and style of the table header.
-See <<header>> for the theme keys that apply to individual header cells
-.
+See <<header>> for the theme keys that apply to individual header cells.
+
 [cols="3,4,6a"]
 |===
 |Key |Value Type |Example


### PR DESCRIPTION
Thanks for all the work for the Asciidoctor PDF. As the recent announcements mentioned the docs, I'd like to support this release with a review of the docs with a grammar an spell checker. 

A review of a native speaker would still be helpful, please edit/discard my suggestions as you see them fit.

I saw that the text uses both `semi-colons` and `semicolons`, I went for `semicolons` in all places.