### PR TITLE
resolves #2219 fix layout of collapsible block

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -9,6 +9,7 @@ For a detailed view of what has changed, refer to the {url-repo}/commits/main[co
 
 Bug Fixes::
 
+* indent content of collapsible block and apply bottom margin to match style of HTML output (#2219)
 * patch prawn-gmagick to reread bit depth of a PNG image if it extracts the wrong value (#2216)
 * interpret width of SVG correctly when width is defined in file using px units (#2215)
 * don't crash if inline role defines border width but not border color


### PR DESCRIPTION
* indent content to align with start of title
* apply bottom margin, if appropriate
* use fallback title if title is not specified
* delegate conversion of collapsible block to convert_collapsible method