### PR TITLE
resolves #2330 allow PDF optimizer to be pluggable

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -19,6 +19,8 @@ Enhancements::
 * rename `kbd-separator` theme key to `kbd-separator-content` to make its consistent with other content keys; remap old key and warn
 * preserve em and rem units on numerator in calc operation in theme (#2314)
 * allow optimizer to be specified using `:pdf_optimizer` API option (#1785)
+* allow custom optimizer to be registered by extending `Asciidoctor::PDF::Optimizer::Base` and calling `register_for` method (#2330)
+* allow custom optimizer to be selected using `pdf-optimizer` attribute (#2330)
 
 Improvements::
 

--- a/bin/asciidoctor-pdf-optimize
+++ b/bin/asciidoctor-pdf-optimize
@@ -1,10 +1,10 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-if File.file? (optimizer = File.join (File.dirname __dir__), 'lib/asciidoctor/pdf/optimizer.rb')
+if File.file? (optimizer = File.join (File.dirname __dir__), 'lib/asciidoctor/pdf/optimizer/rghost.rb')
   require optimizer
 else
-  require 'asciidoctor/pdf/optimizer'
+  require 'asciidoctor/pdf/optimizer/rghost'
 end
 
 args = ARGV.dup
@@ -16,4 +16,4 @@ end
 
 quality = args[0] == '--quality' ? args[1].to_s : ''
 
-(Asciidoctor::PDF::Optimizer.new quality).optimize_file filename
+(Asciidoctor::PDF::Optimizer::RGhost.new quality).optimize_file filename

--- a/docs/modules/ROOT/examples/optimizer-hexapdf.rb
+++ b/docs/modules/ROOT/examples/optimizer-hexapdf.rb
@@ -1,0 +1,30 @@
+require 'hexapdf/cli'
+
+class OptimizerHexaPDF < Asciidoctor::PDF::Optimizer::Base
+  register_for 'hexapdf'
+
+  def initialize *_args
+    super
+    app = HexaPDF::CLI::Application.new
+    app.instance_variable_set :@force, true
+    @optimize = app.main_command.commands['optimize']
+    @optimize.singleton_class.attr_reader :out_options
+    options = @optimize.out_options
+    options.compress_pages = true
+    #options.object_streams = :preserve
+    #options.xref_streams = :preserve
+    #options.streams = :preserve # or :uncompress
+  end
+
+  def optimize_file path
+    @optimize.execute path, path
+    nil
+  rescue
+    # retry without page compression, which can sometimes fail
+    @optimize.out_options.compress_pages = false
+    @optimize.execute path, path
+    nil
+  ensure
+    @optimize.out_options.compress_pages = false
+  end
+end

--- a/docs/modules/ROOT/pages/optimize-pdf.adoc
+++ b/docs/modules/ROOT/pages/optimize-pdf.adoc
@@ -135,45 +135,7 @@ This command does not manipulate the images in any way.
 It merely compresses the objects in the PDF and prunes any unreachable references.
 But given how much waste Prawn leaves behind, this turns out to reduce the file size substantially.
 
-You can hook this command directly into the converter by providing your own implementation of the `Optimizer` class.
-Start by creating a Ruby file named [.path]_optimizer-hexapdf.rb_, then populate it with the following code:
-
-.optimizer-hexapdf.rb
-[source,ruby]
-----
-require 'hexapdf/cli'
-
-class Asciidoctor::PDF::Optimizer
-  def initialize(*)
-    app = HexaPDF::CLI::Application.new
-    app.instance_variable_set :@force, true
-    @optimize = app.main_command.commands['optimize']
-  end
-
-  def optimize_file path
-    options = @optimize.instance_variable_get :@out_options
-    options.compress_pages = true
-    #options.object_streams = :preserve
-    #options.xref_streams = :preserve
-    #options.streams = :preserve # or :uncompress
-    @optimize.execute path, path
-    nil
-  rescue
-    # retry without page compression, which can sometimes fail
-    options.compress_pages = false
-    @optimize.execute path, path
-    nil
-  end
-end
-----
-
-To activate your custom optimizer, load this file when invoking the `asciidoctor-pdf` using the `-r` flag and set the `optimize` attribute as well using the `-a` flag.
-
- $ asciidoctor-pdf -r ./optimizer-hexapdf.rb -a optimize filename.adoc
-
-Now you can convert and optimize all in one go.
-
-To see more options that `hexapdf optimize` offers, run:
+To see all the options that `hexapdf optimize` offers, run:
 
  $ hexapdf help optimize
 
@@ -181,6 +143,39 @@ For example, to make the source of the PDF a bit more readable (though less opti
 You can also disable page compression (e.g., `--no-compress-pages` from the CLI or `options.compress_pages = false` from the API).
 
 hexapdf also allows you to add password protection to your PDF, if that's something you're interested in doing.
+
+=== Define an optimizer
+
+You can hook HexaPDF directly into the conversion process by providing your own implementation of the `Optimizer` class.
+Start by creating a Ruby file named [.path]_optimizer-hexapdf.rb_ where you will define the optimizer.
+Next, populate that file with the following code:
+
+.optimizer-hexapdf.rb
+[source,ruby]
+----
+include::example$optimizer-hexapdf.rb[]
+----
+
+To activate your custom optimizer when using the `asciidoctor-pdf` command, load the optimizer code using the `-r` flag, then set both the `optimize` and `pdf-optimizer` attributes using the `-a` flag.
+
+ $ asciidoctor-pdf -r ./optimizer-hexapdf.rb -a optimize -a pdf-optimizer=hexapdf filename.adoc
+
+If you're calling Asciidoctor PDF using the API, you can pass in the optimizer class directly with the `:pdf_optimizer` option:
+
+[,ruby]
+----
+require 'asciidoctor/pdf'
+require_relative 'optimizer-hexapdf'
+
+Asciidoctor.convert_file 'filename.adoc',
+  safe: :safe,
+  attributes: 'optimize',
+  pdf_optimizer: OptimizerHexaPDF
+----
+
+TIP: When you pass the optimizer class directly to the API, the `register_for` call in the class declaration to self-register the class with a keyword is not required.
+
+You've now converted the input file to PDF and optimized it all in one go!
 
 == Rasterizing the PDF
 

--- a/lib/asciidoctor/pdf/converter.rb
+++ b/lib/asciidoctor/pdf/converter.rb
@@ -3,6 +3,7 @@
 require_relative 'formatted_string'
 require_relative 'formatted_text'
 require_relative 'index_catalog'
+require_relative 'optimizer'
 require_relative 'pdfmark'
 require_relative 'roman_numeral'
 require_relative 'section_info_by_page'
@@ -37,7 +38,6 @@ module Asciidoctor
       CodeRayRequirePath = ::File.join __dir__, 'ext/prawn/coderay_encoder'
       RougeRequirePath = ::File.join __dir__, 'ext/rouge'
       PygmentsRequirePath = ::File.join __dir__, 'ext/pygments'
-      OptimizerRequirePath = ::File.join __dir__, 'optimizer'
 
       AdmonitionIcons = {
         caution: { name: 'fas-fire', stroke_color: 'BF3400' },
@@ -420,8 +420,7 @@ module Asciidoctor
         @pdfmark = (doc.attr? 'pdfmark') ? (Pdfmark.new doc) : nil
         # NOTE: defer instantiating optimizer until we know min pdf version
         if (optimize = doc.attr 'optimize') &&
-            (optimizer = doc.options[:pdf_optimizer] || (((defined? ::Asciidoctor::PDF::Optimizer) ||
-            !(Helpers.require_library OptimizerRequirePath, 'rghost', :warn).nil?) && ::Asciidoctor::PDF::Optimizer))
+            (optimizer = doc.options[:pdf_optimizer] || (Optimizer.for (doc.attr 'pdf-optimizer', 'rghost')))
           @optimize = (optimize.include? ',') ?
             ([:quality, :compliance].zip (optimize.split ',', 2)).to_h :
             ((optimize.include? '/') ? { compliance: optimize } : { quality: optimize })

--- a/lib/asciidoctor/pdf/optimizer/rghost.rb
+++ b/lib/asciidoctor/pdf/optimizer/rghost.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require_relative '../optimizer' unless defined? ::Asciidoctor::PDF::Optimizer
+require 'pathname'
+require 'rghost'
+require 'rghost/gs_alone'
+require 'tmpdir'
+
+RGhost::GSAlone.prepend (Module.new do
+  def initialize params, debug
+    (@params = params.dup).push(*(@params.pop.split File::PATH_SEPARATOR))
+    @debug = debug
+  end
+
+  def run
+    RGhost::Config.config_platform unless File.exist? RGhost::Config::GS[:path].to_s
+    (cmd = @params.slice 1, @params.length).unshift RGhost::Config::GS[:path].to_s
+    #puts cmd if @debug
+    system(*cmd)
+  end
+end)
+
+RGhost::Engine.prepend (Module.new do
+  def shellescape str
+    str
+  end
+end)
+
+module Asciidoctor
+  module PDF
+    class Optimizer::RGhost < Optimizer::Base
+      # see https://www.ghostscript.com/doc/current/VectorDevices.htm#PSPDF_IN for details
+      (QUALITY_NAMES = {
+        'default' => :default,
+        'screen' => :screen,
+        'ebook' => :ebook,
+        'printer' => :printer,
+        'prepress' => :prepress,
+      }).default = :default
+
+      def initialize *_args
+        super
+        if (gs_path = ::ENV['GS'])
+          ::RGhost::Config::GS[:path] = gs_path
+        end
+      end
+
+      def optimize_file target
+        ::Dir::Tmpname.create ['asciidoctor-pdf-', '.pdf'] do |tmpfile|
+          filename_o = ::Pathname.new target
+          filename_tmp = ::Pathname.new tmpfile
+          if (pdfmark = filename_o.sub_ext '.pdfmark').file?
+            inputs = [target, pdfmark.to_s].join ::File::PATH_SEPARATOR
+          else
+            inputs = target
+          end
+          d = { Printed: false, CannotEmbedFontPolicy: '/Warning', CompatibilityLevel: @compatibility_level }
+          case @compliance
+          when 'PDF/A', 'PDF/A-1', 'PDF/A-2', 'PDF/A-3'
+            d[:PDFA] = ((@compliance.split '-', 2)[1] || 1).to_i
+            d[:ShowAnnots] = false
+          when 'PDF/X', 'PDF/X-1', 'PDF/X-3'
+            d[:PDFX] = true
+            d[:ShowAnnots] = false
+          end
+          (::RGhost::Convert.new inputs).to :pdf, filename: filename_tmp.to_s, quality: QUALITY_NAMES[@quality], d: d
+          filename_o.binwrite filename_tmp.binread
+        end
+        nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
* allow custom optimizer to be registered by extending Asciidoctor::PDF::Optimizer::Base and calling register_for method
* allow custom optimizer to be selected using pdf-optimizer attribute