### PR TITLE
Add support for the material design icons set (mdi)

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -21,6 +21,7 @@ Enhancements::
 * allow optimizer to be specified using `:pdf_optimizer` API option (#1785)
 * allow custom optimizer to be registered by extending `Asciidoctor::PDF::Optimizer::Base` and calling `register_for` method (#2330)
 * allow custom optimizer to be selected using `pdf-optimizer` attribute (#2330)
+* upgrade to prawn-icon 3.1.x to add support for the Material Design Icons (`mdi`) as an available font-based icon set (PR #2334)
 
 Improvements::
 

--- a/asciidoctor-pdf.gemspec
+++ b/asciidoctor-pdf.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'prawn-table', '~> 0.2.0'
   s.add_runtime_dependency 'prawn-templates', '~> 0.1.0'
   s.add_runtime_dependency 'prawn-svg', '~> 0.32.0'
-  s.add_runtime_dependency 'prawn-icon', '~> 3.0.0'
+  s.add_runtime_dependency 'prawn-icon', '~> 3.1.0'
   s.add_runtime_dependency 'concurrent-ruby', '~> 1.1'
   s.add_runtime_dependency 'treetop', '~> 1.6.0'
 

--- a/docs/modules/ROOT/pages/icons.adoc
+++ b/docs/modules/ROOT/pages/icons.adoc
@@ -45,6 +45,7 @@ You can use font-based icons from any of the following icon sets in your PDF doc
 * *fab* - https://fontawesome.com/icons?d=gallery&s=brands[Font Awesome - Brands^]
 * *far* - https://fontawesome.com/icons?d=gallery&s=regular[Font Awesome - Regular^]
 * *fi* - http://zurb.com/playground/foundation-icon-fonts-3[Foundation Icons^]
+* *mdi* - https://materialdesignicons.com[Material Design Icons^]
 
 Use of the fa icon set is deprecated.
 Please use one of the styled FontAwesome icon sets.

--- a/lib/asciidoctor/pdf/ext/prawn/extensions.rb
+++ b/lib/asciidoctor/pdf/ext/prawn/extensions.rb
@@ -16,7 +16,7 @@ module Asciidoctor
       ColumnBox = ::Prawn::Document::ColumnBox
 
       FontAwesomeIconSets = %w(fab far fas)
-      IconSets = %w(fab far fas fi).to_set
+      IconSets = %w(fab far fas fi mdi).to_set
       IconSetPrefixes = IconSets.map {|it| it + '-' }
       InitialPageContent = %(q\n)
       (FontStyleToSet = {

--- a/spec/icon_spec.rb
+++ b/spec/icon_spec.rb
@@ -63,6 +63,7 @@ describe 'Asciidoctor::PDF::Converter - Icon' do
       %W(far bell \uf0f3 FontAwesome5Free-Regular),
       %W(fas lock \uf023 FontAwesome5Free-Solid),
       %W(fi lock \uf16a fontcustom),
+      %W(mdi alien \uf089 MaterialDesignIcons),
     ].each do |icon_set, icon_name, char_code, font_name|
       pdf = to_pdf <<~EOS, analyze: true
       :icons: font


### PR DESCRIPTION
Material Design Icon font set (https://materialdesignicons.com/) has just been integrated into prawn-icon. This patch allows this icon set to be used with Asciicoctor.

Thanks for the great job done with asciidoctor/asciidoctor-pdf.