### PR TITLE
document how to show author etc. without title page

### DIFF
--- a/docs/modules/extend/examples/pdf-converter-article-title-with-author-and-date.rb
+++ b/docs/modules/extend/examples/pdf-converter-article-title-with-author-and-date.rb
@@ -4,7 +4,7 @@ class PDFConverterArticleTitleWithAuthorAndDate < (Asciidoctor::Converter.for 'p
   def ink_general_heading doc, title, opts
     return super unless opts[:role] == :doctitle # <1>
     ink_document_title title, opts # <2>
-    ink_document_metainfo doc
+    ink_document_metainfo doc, opts
     ink_titlesection_body_separator
   end
 
@@ -26,14 +26,14 @@ class PDFConverterArticleTitleWithAuthorAndDate < (Asciidoctor::Converter.for 'p
     end
   end
 
-  def ink_document_metainfo doc
+  def ink_document_metainfo doc, opts
     revremark = doc.attr 'revremark' # <3>
     if doc.author || doc.revdate || revremark # <4>
       move_down @theme.heading_h1_documentmetainfo_margin_top || 0
       theme_font_cascade [:base, :heading_h1_documentmetainfo] do
         author_date_separator = (doc.author && doc.revdate) ? ' – ' : '' # <5>
         revremark_separator = ((doc.author || doc.revdate) && revremark) ? ' | ' : '' # <6>
-        ink_prose %(#{doc.author}#{author_date_separator}#{doc.revdate}#{revremark_separator}#{revremark}), align: :center # <7>
+        ink_prose %(#{doc.author}#{author_date_separator}#{doc.revdate}#{revremark_separator}#{revremark}), align: opts[:align] # <7>
       end
     end
   end

--- a/docs/modules/extend/examples/pdf-converter-article-title-with-author-and-date.rb
+++ b/docs/modules/extend/examples/pdf-converter-article-title-with-author-and-date.rb
@@ -31,8 +31,8 @@ class PDFConverterArticleTitleWithAuthorAndDate < (Asciidoctor::Converter.for 'p
     if doc.author || doc.revdate || revremark # <6>
       move_down @theme.heading_h1_documentmetainfo_margin_top || 0
       theme_font_cascade [:base, :heading_h1_documentmetainfo] do
-        author_date_separator = (doc.author && doc.revdate) ? ' – ' : '' # <7>
-        revremark_separator = ((doc.author || doc.revdate) && revremark) ? ' | ' : '' # <8>
+        author_date_separator = doc.author && doc.revdate ? ' – ' : '' # <7>
+        revremark_separator = (doc.author || doc.revdate) && revremark ? ' | ' : '' # <8>
         ink_prose %(#{doc.author}#{author_date_separator}#{doc.revdate}#{revremark_separator}#{revremark}), align: opts[:align] # <9>
       end
     end

--- a/docs/modules/extend/examples/pdf-converter-article-title-with-author-and-date.rb
+++ b/docs/modules/extend/examples/pdf-converter-article-title-with-author-and-date.rb
@@ -9,9 +9,9 @@ class PDFConverterArticleTitleWithAuthorAndDate < (Asciidoctor::Converter.for 'p
     revremark = doc.attributes['revremark'] # <3>
     if doc.author || doc.revdate || revremark # <4>
       theme_font :base do
-        author_date_separator = (doc.author && doc.revdate) ? " – " : "" # <5>
-        revremark_separator = ((doc.author || doc.revdate) && revremark) ? " | " : "" # <6>
-        ink_prose "#{doc.author}#{author_date_separator}#{doc.revdate}#{revremark_separator}#{revremark}", align: :center # <7>
+        author_date_separator = (doc.author && doc.revdate) ? ' – ' : '' # <5>
+        revremark_separator = ((doc.author || doc.revdate) && revremark) ? ' | ' : '' # <6>
+        ink_prose %(#{doc.author}#{author_date_separator}#{doc.revdate}#{revremark_separator}#{revremark}), align: :center # <7>
       end
     end
     theme_margin :heading_doctitle, :bottom

--- a/docs/modules/extend/examples/pdf-converter-article-title-with-author-and-date.rb
+++ b/docs/modules/extend/examples/pdf-converter-article-title-with-author-and-date.rb
@@ -4,7 +4,7 @@ class PDFConverterArticleTitleWithAuthorAndDate < (Asciidoctor::Converter.for 'p
   def ink_general_heading doc, title, opts
     return super unless opts[:role] == :doctitle # <1>
     ink_document_title title, opts # <2>
-    ink_document_metainfo doc, opts # <3>
+    ink_document_details doc, opts # <3>
     margin_bottom @theme[:heading_h1_margin_bottom] || @theme.heading_margin_bottom # <4>
   end
 
@@ -26,7 +26,7 @@ class PDFConverterArticleTitleWithAuthorAndDate < (Asciidoctor::Converter.for 'p
     end
   end
 
-  def ink_document_metainfo doc, opts
+  def ink_document_details doc, opts
     revremark = doc.attr 'revremark' # <5>
     if doc.author || doc.revdate || revremark # <6>
       move_down @theme.heading_h1_details_margin_top || 0 # <7>

--- a/docs/modules/extend/examples/pdf-converter-article-title-with-author-and-date.rb
+++ b/docs/modules/extend/examples/pdf-converter-article-title-with-author-and-date.rb
@@ -5,7 +5,7 @@ class PDFConverterArticleTitleWithAuthorAndDate < (Asciidoctor::Converter.for 'p
     return super unless opts[:role] == :doctitle # <1>
     ink_document_title title # <2>
     ink_document_metainfo doc
-    theme_margin :heading_doctitle, :bottom
+    ink_titlesection_body_separator
   end
 
   def ink_document_title title
@@ -23,5 +23,9 @@ class PDFConverterArticleTitleWithAuthorAndDate < (Asciidoctor::Converter.for 'p
         ink_prose %(#{doc.author}#{author_date_separator}#{doc.revdate}#{revremark_separator}#{revremark}), align: :center # <7>
       end
     end
+  end
+
+  def ink_titlesection_body_separator
+    theme_margin :heading_doctitle, :bottom
   end
 end

--- a/docs/modules/extend/examples/pdf-converter-article-title-with-author-and-date.rb
+++ b/docs/modules/extend/examples/pdf-converter-article-title-with-author-and-date.rb
@@ -4,8 +4,8 @@ class PDFConverterArticleTitleWithAuthorAndDate < (Asciidoctor::Converter.for 'p
   def ink_general_heading doc, title, opts
     return super unless opts[:role] == :doctitle # <1>
     ink_document_title title, opts # <2>
-    ink_document_metainfo doc, opts
-    ink_titlesection_body_separator
+    ink_document_metainfo doc, opts # <3>
+    ink_titlesection_body_separator # <4>
   end
 
   def ink_document_title title, opts
@@ -27,13 +27,13 @@ class PDFConverterArticleTitleWithAuthorAndDate < (Asciidoctor::Converter.for 'p
   end
 
   def ink_document_metainfo doc, opts
-    revremark = doc.attr 'revremark' # <3>
-    if doc.author || doc.revdate || revremark # <4>
+    revremark = doc.attr 'revremark' # <5>
+    if doc.author || doc.revdate || revremark # <6>
       move_down @theme.heading_h1_documentmetainfo_margin_top || 0
       theme_font_cascade [:base, :heading_h1_documentmetainfo] do
-        author_date_separator = (doc.author && doc.revdate) ? ' – ' : '' # <5>
-        revremark_separator = ((doc.author || doc.revdate) && revremark) ? ' | ' : '' # <6>
-        ink_prose %(#{doc.author}#{author_date_separator}#{doc.revdate}#{revremark_separator}#{revremark}), align: opts[:align] # <7>
+        author_date_separator = (doc.author && doc.revdate) ? ' – ' : '' # <7>
+        revremark_separator = ((doc.author || doc.revdate) && revremark) ? ' | ' : '' # <8>
+        ink_prose %(#{doc.author}#{author_date_separator}#{doc.revdate}#{revremark_separator}#{revremark}), align: opts[:align] # <9>
       end
     end
   end

--- a/docs/modules/extend/examples/pdf-converter-article-title-with-author-and-date.rb
+++ b/docs/modules/extend/examples/pdf-converter-article-title-with-author-and-date.rb
@@ -4,6 +4,17 @@ class PDFConverterArticleTitleWithAuthorAndDate < (Asciidoctor::Converter.for 'p
   def ink_general_heading doc, title, opts
     return super unless opts[:role] == :doctitle # <1>
     ink_document_title title # <2>
+    ink_document_metainfo doc
+    theme_margin :heading_doctitle, :bottom
+  end
+
+  def ink_document_title title
+    theme_font :heading_doctitle do
+      ink_prose title, align: :center
+    end
+  end
+
+  def ink_document_metainfo doc
     revremark = doc.attr 'revremark' # <3>
     if doc.author || doc.revdate || revremark # <4>
       theme_font :base do
@@ -11,13 +22,6 @@ class PDFConverterArticleTitleWithAuthorAndDate < (Asciidoctor::Converter.for 'p
         revremark_separator = ((doc.author || doc.revdate) && revremark) ? ' | ' : '' # <6>
         ink_prose %(#{doc.author}#{author_date_separator}#{doc.revdate}#{revremark_separator}#{revremark}), align: :center # <7>
       end
-    end
-    theme_margin :heading_doctitle, :bottom
-  end
-
-  def ink_document_title title
-    theme_font :heading_doctitle do
-      ink_prose title, align: :center
     end
   end
 end

--- a/docs/modules/extend/examples/pdf-converter-article-title-with-author-and-date.rb
+++ b/docs/modules/extend/examples/pdf-converter-article-title-with-author-and-date.rb
@@ -3,14 +3,26 @@ class PDFConverterArticleTitleWithAuthorAndDate < (Asciidoctor::Converter.for 'p
 
   def ink_general_heading doc, title, opts
     return super unless opts[:role] == :doctitle # <1>
-    ink_document_title title # <2>
+    ink_document_title title, opts # <2>
     ink_document_metainfo doc
     ink_titlesection_body_separator
   end
 
-  def ink_document_title title
-    theme_font :heading_doctitle do
-      ink_prose title, align: :center
+  def ink_document_title title, opts
+    if (top_margin = @theme.heading_h1_margin_page_top || @theme.heading_margin_page_top) > 0
+      move_down top_margin
+    end
+    pad_box @theme.heading_h1_padding do
+      if (transform = resolve_text_transform opts)
+        title = transform_text title, transform
+      end
+      if (inherited = apply_text_decoration font_styles, :heading, 1).empty?
+        inline_format_opts = true
+      else
+        inline_format_opts = [{ inherited: inherited }]
+      end
+      typeset_text_opts = { color: @font_color, inline_format: inline_format_opts }.merge opts
+      typeset_text title, (calc_line_metrics (opts.delete :line_height) || @base_line_height), typeset_text_opts 
     end
   end
 
@@ -26,6 +38,6 @@ class PDFConverterArticleTitleWithAuthorAndDate < (Asciidoctor::Converter.for 'p
   end
 
   def ink_titlesection_body_separator
-    theme_margin :heading_doctitle, :bottom
+    margin_bottom @theme[:heading_h1_margin_bottom] || @theme.heading_margin_bottom
   end
 end

--- a/docs/modules/extend/examples/pdf-converter-article-title-with-author-and-date.rb
+++ b/docs/modules/extend/examples/pdf-converter-article-title-with-author-and-date.rb
@@ -1,0 +1,19 @@
+class PDFConverterArticleTitleWithAuthorAndDate < (Asciidoctor::Converter.for 'pdf')
+  register_for 'pdf'
+
+  def ink_general_heading doc, title, opts
+    return super unless opts[:role] == :doctitle # <1>
+    theme_font :heading_doctitle do
+      ink_prose title, align: :center # <2>
+    end
+    revremark = doc.attributes['revremark'] # <3>
+    if doc.author or doc.revdate or revremark # <4>
+      theme_font :base do
+        author_date_separator = (doc.author and doc.revdate) ? " – " : "" # <5>
+        revremark_separator = ((doc.author or doc.revdate) and revremark) ? " | " : "" # <6>
+        ink_prose "#{doc.author}#{author_date_separator}#{doc.revdate}#{revremark_separator}#{revremark}", align: :center # <7>
+      end
+    end
+    theme_margin :heading_doctitle, :bottom
+  end
+end

--- a/docs/modules/extend/examples/pdf-converter-article-title-with-author-and-date.rb
+++ b/docs/modules/extend/examples/pdf-converter-article-title-with-author-and-date.rb
@@ -29,7 +29,8 @@ class PDFConverterArticleTitleWithAuthorAndDate < (Asciidoctor::Converter.for 'p
   def ink_document_metainfo doc
     revremark = doc.attr 'revremark' # <3>
     if doc.author || doc.revdate || revremark # <4>
-      theme_font :base do
+      move_down @theme.heading_h1_documentmetainfo_margin_top || 0
+      theme_font_cascade [:base, :heading_h1_documentmetainfo] do
         author_date_separator = (doc.author && doc.revdate) ? ' – ' : '' # <5>
         revremark_separator = ((doc.author || doc.revdate) && revremark) ? ' | ' : '' # <6>
         ink_prose %(#{doc.author}#{author_date_separator}#{doc.revdate}#{revremark_separator}#{revremark}), align: :center # <7>

--- a/docs/modules/extend/examples/pdf-converter-article-title-with-author-and-date.rb
+++ b/docs/modules/extend/examples/pdf-converter-article-title-with-author-and-date.rb
@@ -3,9 +3,7 @@ class PDFConverterArticleTitleWithAuthorAndDate < (Asciidoctor::Converter.for 'p
 
   def ink_general_heading doc, title, opts
     return super unless opts[:role] == :doctitle # <1>
-    theme_font :heading_doctitle do
-      ink_prose title, align: :center # <2>
-    end
+    ink_document_title title # <2>
     revremark = doc.attr 'revremark' # <3>
     if doc.author || doc.revdate || revremark # <4>
       theme_font :base do
@@ -15,5 +13,11 @@ class PDFConverterArticleTitleWithAuthorAndDate < (Asciidoctor::Converter.for 'p
       end
     end
     theme_margin :heading_doctitle, :bottom
+  end
+
+  def ink_document_title title
+    theme_font :heading_doctitle do
+      ink_prose title, align: :center
+    end
   end
 end

--- a/docs/modules/extend/examples/pdf-converter-article-title-with-author-and-date.rb
+++ b/docs/modules/extend/examples/pdf-converter-article-title-with-author-and-date.rb
@@ -29,8 +29,8 @@ class PDFConverterArticleTitleWithAuthorAndDate < (Asciidoctor::Converter.for 'p
   def ink_document_metainfo doc, opts
     revremark = doc.attr 'revremark' # <5>
     if doc.author || doc.revdate || revremark # <6>
-      move_down @theme.heading_h1_documentmetainfo_margin_top || 0
-      theme_font_cascade [:base, :heading_h1_documentmetainfo] do
+      move_down @theme.heading_h1_details_margin_top || 0
+      theme_font_cascade [:base, :heading_h1_details] do
         author_date_separator = doc.author && doc.revdate ? %( #{EmDash} ) : '' # <7>
         revremark_separator = (doc.author || doc.revdate) && revremark ? ' | ' : '' # <8>
         ink_prose %(#{doc.author}#{author_date_separator}#{doc.revdate}#{revremark_separator}#{revremark}), align: opts[:align] # <9>

--- a/docs/modules/extend/examples/pdf-converter-article-title-with-author-and-date.rb
+++ b/docs/modules/extend/examples/pdf-converter-article-title-with-author-and-date.rb
@@ -6,7 +6,7 @@ class PDFConverterArticleTitleWithAuthorAndDate < (Asciidoctor::Converter.for 'p
     theme_font :heading_doctitle do
       ink_prose title, align: :center # <2>
     end
-    revremark = doc.attributes['revremark'] # <3>
+    revremark = doc.attr 'revremark' # <3>
     if doc.author || doc.revdate || revremark # <4>
       theme_font :base do
         author_date_separator = (doc.author && doc.revdate) ? ' – ' : '' # <5>

--- a/docs/modules/extend/examples/pdf-converter-article-title-with-author-and-date.rb
+++ b/docs/modules/extend/examples/pdf-converter-article-title-with-author-and-date.rb
@@ -5,7 +5,7 @@ class PDFConverterArticleTitleWithAuthorAndDate < (Asciidoctor::Converter.for 'p
     return super unless opts[:role] == :doctitle # <1>
     ink_document_title title, opts # <2>
     ink_document_metainfo doc, opts # <3>
-    ink_titlesection_body_separator # <4>
+    margin_bottom @theme[:heading_h1_margin_bottom] || @theme.heading_margin_bottom # <4>
   end
 
   def ink_document_title title, opts
@@ -36,9 +36,5 @@ class PDFConverterArticleTitleWithAuthorAndDate < (Asciidoctor::Converter.for 'p
         ink_prose %(#{doc.author}#{author_date_separator}#{doc.revdate}#{revremark_separator}#{revremark}), align: opts[:align] # <11>
       end
     end
-  end
-
-  def ink_titlesection_body_separator
-    margin_bottom @theme[:heading_h1_margin_bottom] || @theme.heading_margin_bottom
   end
 end

--- a/docs/modules/extend/examples/pdf-converter-article-title-with-author-and-date.rb
+++ b/docs/modules/extend/examples/pdf-converter-article-title-with-author-and-date.rb
@@ -7,10 +7,10 @@ class PDFConverterArticleTitleWithAuthorAndDate < (Asciidoctor::Converter.for 'p
       ink_prose title, align: :center # <2>
     end
     revremark = doc.attributes['revremark'] # <3>
-    if doc.author or doc.revdate or revremark # <4>
+    if doc.author || doc.revdate || revremark # <4>
       theme_font :base do
-        author_date_separator = (doc.author and doc.revdate) ? " – " : "" # <5>
-        revremark_separator = ((doc.author or doc.revdate) and revremark) ? " | " : "" # <6>
+        author_date_separator = (doc.author && doc.revdate) ? " – " : "" # <5>
+        revremark_separator = ((doc.author || doc.revdate) && revremark) ? " | " : "" # <6>
         ink_prose "#{doc.author}#{author_date_separator}#{doc.revdate}#{revremark_separator}#{revremark}", align: :center # <7>
       end
     end

--- a/docs/modules/extend/examples/pdf-converter-article-title-with-author-and-date.rb
+++ b/docs/modules/extend/examples/pdf-converter-article-title-with-author-and-date.rb
@@ -31,7 +31,7 @@ class PDFConverterArticleTitleWithAuthorAndDate < (Asciidoctor::Converter.for 'p
     if doc.author || doc.revdate || revremark # <6>
       move_down @theme.heading_h1_documentmetainfo_margin_top || 0
       theme_font_cascade [:base, :heading_h1_documentmetainfo] do
-        author_date_separator = doc.author && doc.revdate ? ' – ' : '' # <7>
+        author_date_separator = doc.author && doc.revdate ? %( #{EmDash} ) : '' # <7>
         revremark_separator = (doc.author || doc.revdate) && revremark ? ' | ' : '' # <8>
         ink_prose %(#{doc.author}#{author_date_separator}#{doc.revdate}#{revremark_separator}#{revremark}), align: opts[:align] # <9>
       end

--- a/docs/modules/extend/examples/pdf-converter-article-title-with-author-and-date.rb
+++ b/docs/modules/extend/examples/pdf-converter-article-title-with-author-and-date.rb
@@ -29,11 +29,11 @@ class PDFConverterArticleTitleWithAuthorAndDate < (Asciidoctor::Converter.for 'p
   def ink_document_metainfo doc, opts
     revremark = doc.attr 'revremark' # <5>
     if doc.author || doc.revdate || revremark # <6>
-      move_down @theme.heading_h1_details_margin_top || 0
-      theme_font_cascade [:base, :heading_h1_details] do
-        author_date_separator = doc.author && doc.revdate ? %( #{EmDash} ) : '' # <7>
-        revremark_separator = (doc.author || doc.revdate) && revremark ? ' | ' : '' # <8>
-        ink_prose %(#{doc.author}#{author_date_separator}#{doc.revdate}#{revremark_separator}#{revremark}), align: opts[:align] # <9>
+      move_down @theme.heading_h1_details_margin_top || 0 # <7>
+      theme_font_cascade [:base, :heading_h1_details] do # <8>
+        author_date_separator = doc.author && doc.revdate ? %( #{EmDash} ) : '' # <9>
+        revremark_separator = (doc.author || doc.revdate) && revremark ? ' | ' : '' # <10>
+        ink_prose %(#{doc.author}#{author_date_separator}#{doc.revdate}#{revremark_separator}#{revremark}), align: opts[:align] # <11>
       end
     end
   end

--- a/docs/modules/extend/pages/use-cases.adoc
+++ b/docs/modules/extend/pages/use-cases.adoc
@@ -75,14 +75,14 @@ include::example$pdf-converter-article-title-with-author-and-date.rb[]
 ----
 <.> Fall back to default implementation unless handling the document title.
 <.> Render the document title.
-    See the definition of `ink_document_title` for details.
+See the definition of `ink_document_title` for details.
 <.> Render author, date and revision remark, if they're available.
-    See the definition of `ink_document_metainfo` for details.
+See the definition of `ink_document_metainfo` for details.
 <.> Render a vertical gap between the title section (incl. author, date and revision remark) and the body of the document.
-    See the definition of `ink_titlesection_body_separator` for details.
+See the definition of `ink_titlesection_body_separator` for details.
 <.> The revision remark isn't available as a field of `doc`, so we have to get it from the hash `doc.attributes`.
-    We could do that with `doc.attributes['revremark']`, but we use the convenience method `doc.attr` instead.
-    Because we'll use the revision remark multiple times, we store it in a local variable.
+We could do that with `doc.attributes['revremark']`, but we use the convenience method `doc.attr` instead.
+Because we'll use the revision remark multiple times, we store it in a local variable.
 <.> Only include the additional line if there's actually content for it, so we don't end up with unused vertical space.
 <.> An em-dash to be put between author and date, but only if both aren't empty.
 <.> A vertical bar to be put before the revision remark, but only if it isn't empty and there's actually something else (author, date or both) in front of it.

--- a/docs/modules/extend/pages/use-cases.adoc
+++ b/docs/modules/extend/pages/use-cases.adoc
@@ -86,7 +86,7 @@ include::example$pdf-converter-article-title-with-author-and-date.rb[]
 <.> Only include the additional line if there's actually content for it, so we don't end up with unused vertical space.
 <.> An em-dash to be put between author and date, but only if both aren't empty.
 <.> A vertical bar to be put before the revision remark, but only if it isn't empty and there's actually something else (author, date or both) in front of it.
-<.> Put everything together using Ruby https://docs.ruby-lang.org/en/3.0/syntax/literals_rdoc.html#label-Strings[string] interpolation and render it.
+<.> Put author, date, revision remark and the separators together using Ruby https://docs.ruby-lang.org/en/3.0/syntax/literals_rdoc.html#label-Strings[string] interpolation and render the resulting string.
 
 == Custom part title
 

--- a/docs/modules/extend/pages/use-cases.adoc
+++ b/docs/modules/extend/pages/use-cases.adoc
@@ -79,7 +79,6 @@ See the definition of `ink_document_title` for details.
 <.> Render author, date and revision remark, if they're available.
 See the definition of `ink_document_metainfo` for details.
 <.> Render a vertical gap between the title section (incl. author, date and revision remark) and the body of the document.
-See the definition of `ink_titlesection_body_separator` for details.
 <.> The revision remark isn't available as a field of `doc`, so we have to get it from the hash `doc.attributes`.
 We could do that with `doc.attributes['revremark']`, but we use the convenience method `doc.attr` instead.
 Because we'll use the revision remark multiple times, we store it in a local variable.

--- a/docs/modules/extend/pages/use-cases.adoc
+++ b/docs/modules/extend/pages/use-cases.adoc
@@ -84,6 +84,15 @@ See the definition of `ink_titlesection_body_separator` for details.
 We could do that with `doc.attributes['revremark']`, but we use the convenience method `doc.attr` instead.
 Because we'll use the revision remark multiple times, we store it in a local variable.
 <.> Only include the additional line if there's actually content for it, so we don't end up with unused vertical space.
+<.> Render a vertical gap between the document title
+and the line with author, date and revision remark
+if the theme sets a size of that gap.
+Otherwise, fall back to a zero-height "`gap`".
+<.> When we get here, a heading-specific style will already be set.
+(This is ensured by the methods that call `ink_general_heading`.)
+As we don't want author, date and revision remark to look like a heading,
+we first have to reset to the default style using the `:base` category.
+Then, we can apply the `heading_h1_details` category.
 <.> An em-dash to be put between author and date, but only if both aren't empty.
 <.> A vertical bar to be put before the revision remark, but only if it isn't empty and there's actually something else (author, date or both) in front of it.
 <.> Put author, date, revision remark and the separators together using Ruby https://docs.ruby-lang.org/en/3.0/syntax/literals_rdoc.html#label-Strings[string] interpolation and render the resulting string.

--- a/docs/modules/extend/pages/use-cases.adoc
+++ b/docs/modules/extend/pages/use-cases.adoc
@@ -62,11 +62,9 @@ Finally, the method `convert` will convert and render the Asciidoctor node that 
 Documents rendered as articles by Asciidoctor PDF don't have a title page by default.
 Instead their document title is shown on the first content page above the actual content.
 
-Other than in articles rendered by Asciidoctor to HTML, and other than when rendered with a title page (e.g. document type book),
-the author, date and revision remark won't be shown by default.
+Other than in articles rendered by Asciidoctor to HTML, and other than when rendered with a title page (e.g. document type book), the author, date and revision remark won't be shown by default.
 To get them included anyway, we can hook into the method `ink_general_heading`, which renders the document title.
-As `ink_general_heading` is also responsible for rendering other "headers" (e.g. section titles),
-we let it fall back to the default implementation for all headers that aren't the document title.
+As `ink_general_heading` is also responsible for rendering other "headers" (e.g. section titles), we let it fall back to the default implementation for all headers that aren't the document title.
 
 .Extended converter with author, date and revision remark below the document title of document types without a title page
 [,ruby]
@@ -79,18 +77,14 @@ See the definition of `ink_document_title` for details.
 <.> Render author, date and revision remark, if they're available.
 See the definition of `ink_document_metainfo` for details.
 <.> Render a vertical gap between the title section (incl. author, date and revision remark) and the body of the document.
-<.> The revision remark isn't available as a field of `doc`,
-so we have to retrieve it using the method `doc.attr` instead.
+<.> The revision remark isn't available as a field of `doc`, so we have to retrieve it using the method `doc.attr` instead.
 Because we'll use the revision remark multiple times, we store it in a local variable.
 <.> Only include the additional line if there's actually content for it, so we don't end up with unused vertical space.
-<.> Render a vertical gap between the document title
-and the line with author, date and revision remark
-if the theme sets a size of that gap.
+<.> Render a vertical gap between the document title and the line with author, date and revision remark if the theme sets a size of that gap.
 Otherwise, fall back to a zero-height "`gap`".
 <.> When we get here, a heading-specific style will already be set.
 (This is ensured by the methods that call `ink_general_heading`.)
-As we don't want author, date and revision remark to look like a heading,
-we first have to reset to the default style using the `:base` category.
+As we don't want author, date and revision remark to look like a heading, we first have to reset to the default style using the `:base` category.
 Then, we can apply the `heading_h1_details` category.
 <.> An em-dash to be put between author and date, but only if both aren't empty.
 <.> A vertical bar to be put before the revision remark, but only if it isn't empty and there's actually something else (author, date or both) in front of it.

--- a/docs/modules/extend/pages/use-cases.adoc
+++ b/docs/modules/extend/pages/use-cases.adoc
@@ -57,6 +57,31 @@ The method `stroke_horizontal_rule` draws a horizontal line using the specified 
 The method `ink_prose` is provided by Asciidoctor PDF to make writing text to the page easier.
 Finally, the method `convert` will convert and render the Asciidoctor node that is passed to it, in this case a block image.
 
+== Custom document header without a title page
+
+Documents rendered as articles by Asciidoctor PDF don't have a title page by default.
+Instead their document title is shown on the first content page above the actual content.
+
+Other than in articles rendered by Asciidoctor to HTML, and other than when rendered with a title page (e.g. document type book),
+the author, date and revision remark won't be shown by default.
+To get them included anyway, we can hook into the method `ink_general_heading`, which renders the document title.
+As `ink_general_heading` is also responsible for rendering other "headers" (e.g. section titles),
+we let it fall back to the default implementation for all headers that aren't the document title.
+
+.Extended converter with author, date and revision remark below the document title of document types without a title page
+[,ruby]
+----
+include::example$pdf-converter-article-title-with-author-and-date.rb[]
+----
+<.> Fall back to default implementation unless handling the document title.
+<.> Render the document title.
+<.> The revision remark isn't available as a field of `doc`, so we have to get it from the hash `doc.attributes`.
+    Because we'll use it multiple times, we store it in a local variable.
+<.> Only include the additional line if there's actually content for it, so we don't end up with unused vertical space.
+<.> An em-dash to be put between author and date, but only if both aren't empty.
+<.> A vertical bar to be put before the revision remark, but only if it isn't empty and there's actually something else (author, date or both) in front of it.
+<.> Put everything together using Ruby https://docs.ruby-lang.org/en/3.0/syntax/literals_rdoc.html#label-Strings[string] interpolation and render it as a center-aligned line.
+
 == Custom part title
 
 A common need is to add extra styling to the title page for a part in a multi-part book.

--- a/docs/modules/extend/pages/use-cases.adoc
+++ b/docs/modules/extend/pages/use-cases.adoc
@@ -81,7 +81,7 @@ include::example$pdf-converter-article-title-with-author-and-date.rb[]
 <.> Only include the additional line if there's actually content for it, so we don't end up with unused vertical space.
 <.> An em-dash to be put between author and date, but only if both aren't empty.
 <.> A vertical bar to be put before the revision remark, but only if it isn't empty and there's actually something else (author, date or both) in front of it.
-<.> Put everything together using Ruby https://docs.ruby-lang.org/en/3.0/syntax/literals_rdoc.html#label-Strings[string] interpolation and render it as a center-aligned line.
+<.> Put everything together using Ruby https://docs.ruby-lang.org/en/3.0/syntax/literals_rdoc.html#label-Strings[string] interpolation and render it.
 
 == Custom part title
 

--- a/docs/modules/extend/pages/use-cases.adoc
+++ b/docs/modules/extend/pages/use-cases.adoc
@@ -75,7 +75,7 @@ include::example$pdf-converter-article-title-with-author-and-date.rb[]
 <.> Render the document title.
 See the definition of `ink_document_title` for details.
 <.> Render author, date and revision remark, if they're available.
-See the definition of `ink_document_metainfo` for details.
+See the definition of `ink_document_details` for details.
 <.> Render a vertical gap between the title section (incl. author, date and revision remark) and the body of the document.
 <.> The revision remark isn't available as a field of `doc`, so we have to retrieve it using the method `doc.attr` instead.
 Because we'll use the revision remark multiple times, we store it in a local variable.

--- a/docs/modules/extend/pages/use-cases.adoc
+++ b/docs/modules/extend/pages/use-cases.adoc
@@ -79,8 +79,8 @@ See the definition of `ink_document_title` for details.
 <.> Render author, date and revision remark, if they're available.
 See the definition of `ink_document_metainfo` for details.
 <.> Render a vertical gap between the title section (incl. author, date and revision remark) and the body of the document.
-<.> The revision remark isn't available as a field of `doc`, so we have to get it from the hash `doc.attributes`.
-We could do that with `doc.attributes['revremark']`, but we use the convenience method `doc.attr` instead.
+<.> The revision remark isn't available as a field of `doc`,
+so we have to retrieve it using the method `doc.attr` instead.
 Because we'll use the revision remark multiple times, we store it in a local variable.
 <.> Only include the additional line if there's actually content for it, so we don't end up with unused vertical space.
 <.> Render a vertical gap between the document title

--- a/docs/modules/extend/pages/use-cases.adoc
+++ b/docs/modules/extend/pages/use-cases.adoc
@@ -75,6 +75,11 @@ include::example$pdf-converter-article-title-with-author-and-date.rb[]
 ----
 <.> Fall back to default implementation unless handling the document title.
 <.> Render the document title.
+    See the definition of `ink_document_title` for details.
+<.> Render author, date and revision remark, if they're available.
+    See the definition of `ink_document_metainfo` for details.
+<.> Render a vertical gap between the title section (incl. author, date and revision remark) and the body of the document.
+    See the definition of `ink_titlesection_body_separator` for details.
 <.> The revision remark isn't available as a field of `doc`, so we have to get it from the hash `doc.attributes`.
     We could do that with `doc.attributes['revremark']`, but we use the convenience method `doc.attr` instead.
     Because we'll use the revision remark multiple times, we store it in a local variable.

--- a/docs/modules/extend/pages/use-cases.adoc
+++ b/docs/modules/extend/pages/use-cases.adoc
@@ -94,7 +94,7 @@ we first have to reset to the default style using the `:base` category.
 Then, we can apply the `heading_h1_details` category.
 <.> An em-dash to be put between author and date, but only if both aren't empty.
 <.> A vertical bar to be put before the revision remark, but only if it isn't empty and there's actually something else (author, date or both) in front of it.
-<.> Put author, date, revision remark and the separators together using Ruby https://docs.ruby-lang.org/en/3.0/syntax/literals_rdoc.html#label-Strings[string] interpolation and render the resulting string.
+<.> Put author, date, revision remark and the separators together using Ruby string interpolation and render the resulting string.
 
 == Custom part title
 

--- a/docs/modules/extend/pages/use-cases.adoc
+++ b/docs/modules/extend/pages/use-cases.adoc
@@ -76,7 +76,8 @@ include::example$pdf-converter-article-title-with-author-and-date.rb[]
 <.> Fall back to default implementation unless handling the document title.
 <.> Render the document title.
 <.> The revision remark isn't available as a field of `doc`, so we have to get it from the hash `doc.attributes`.
-    Because we'll use it multiple times, we store it in a local variable.
+    We could do that with `doc.attributes['revremark']`, but we use the convenience method `doc.attr` instead.
+    Because we'll use the revision remark multiple times, we store it in a local variable.
 <.> Only include the additional line if there's actually content for it, so we don't end up with unused vertical space.
 <.> An em-dash to be put between author and date, but only if both aren't empty.
 <.> A vertical bar to be put before the revision remark, but only if it isn't empty and there's actually something else (author, date or both) in front of it.


### PR DESCRIPTION
Add a use case example that makes `author`, `revdate` and `revremark` visible in document types (e.g. `article`s) without a title page, by hooking into the converter function for the document title and adding these infos in a line below it.

Workaround for #1883

See https://github.com/asciidoctor/asciidoctor-pdf/issues/1883#issuecomment-1637196810