### PR TITLE
resolves #2458 make NoMethodError message check in tests compatible with ruby3.3.0dev

### DIFF
--- a/spec/converter_spec.rb
+++ b/spec/converter_spec.rb
@@ -351,7 +351,7 @@ describe Asciidoctor::PDF::Converter do
         (expect do
           pdf = to_pdf 'content', attribute_overrides: { 'pdf-theme' => (fixture_file 'invalid-theme.yml') }, analyze: true
           (expect pdf.pages).to have_size 1
-        end).to log_message severity: :ERROR, message: /because of NoMethodError undefined method `start_with\?' for 10:(Fixnum|Integer); reverting to default theme/
+        end).to log_message severity: :ERROR, message: /because of NoMethodError undefined method `start_with\?' for (10:|an instance of )(Fixnum|Integer); reverting to default theme/
       end
 
       it 'should not crash if theme does not specify any keys' do


### PR DESCRIPTION
ruby3.3.0dev changes the error messages on NoMethodError with the following commit / issue:

https://github.com/ruby/ruby/pull/6950
https://bugs.ruby-lang.org/issues/18285

So make NoMethodError message check on rspec testsuite compatible with this change.

Fixes #2458 .