### PR TITLE
Update fallback-font.adoc

### DIFF
--- a/docs/modules/theme/pages/fallback-font.adoc
+++ b/docs/modules/theme/pages/fallback-font.adoc
@@ -99,19 +99,24 @@ Now Asciidoctor PDF will look for the emoji in the Symbola font instead of the N
 == Default Microsoft Windows Font Limitations
 When using the fonts provided by default in Microsoft Windows 10, and possibly other versions, it is important to define a fallback font to provide full coverage of Asciidoctor language features.
 In particular, the https://docs.asciidoctor.org/asciidoc/latest/lists/checklist/[Checklist] feature makes use of the _Ballet Box_ ☐ (U+2610) and _Ballot Box with Check_ "☑" (U+2611) characters.
-Two fonts, Segoe UI Symbol (`seuisysm.ttf`) and Segoe UI Emoji (`seguiemj.ttf`), do contain these characters.
+Two fonts provided by Windows, Segoe UI Symbol (`seguisym.ttf`) and Segoe UI Emoji (`seguiemj.ttf`), do contain these characters.
+These two fonts have baselines which match better with most of the Windows font library than the default Notoserif font which is included with Asciidoctor PDF.
 
-Here is an example using Courier with Segoe UI Symbol as a fallback providing the characters needed to support checklists:
+Here is an example using Times New Roman with Segoe UI Symbol as a fallback providing the characters needed to support checklists:
 [,yaml]
 ----
 font:
   catalog:
-    Courier:
-      normal: cour.ttf
-      italic: couri.ttf
-      bold: courbd.ttf
-      bold_italic: courbi.ttf
-    CourierFallback: seuisysm.ttf
+    TimesNewRoman:
+      normal: times.ttf
+      italic: timesi.ttf
+      bold: timesbd.ttf
+      bold_italic: timesbi.ttf
+    TimesNewRomanFallback: seguisym.ttf
   fallbacks:
-  - CourierFallback
+  - TimesNewRomanFallback
 ----
+
+Make sure to configure the theme to include the location of the Windows font files, which is `c:\Windows\Fonts`.
+
+

--- a/docs/modules/theme/pages/fallback-font.adoc
+++ b/docs/modules/theme/pages/fallback-font.adoc
@@ -112,9 +112,9 @@ font:
       italic: timesi.ttf
       bold: timesbd.ttf
       bold_italic: timesbi.ttf
-    TimesNewRomanFallback: seguisym.ttf
+    SegoeUISymbolFallback: seguisym.ttf
   fallbacks:
-  - TimesNewRomanFallback
+  - SegoeUISymbolFallback
 ----
 
 Make sure to configure the theme to include the location of the Windows font files, which is `c:\Windows\Fonts`.

--- a/docs/modules/theme/pages/fallback-font.adoc
+++ b/docs/modules/theme/pages/fallback-font.adoc
@@ -96,10 +96,12 @@ font:
 
 Now Asciidoctor PDF will look for the emoji in the Symbola font instead of the Noto Emoji font.
 
-== Default Microsoft Windows Font Limitations
+== Default Microsoft Windows Font Fallbacks
+
 When using the fonts provided by default in Microsoft Windows 10, and possibly other versions, it is important to define a fallback font to provide full coverage of Asciidoctor language features.
-In particular, the https://docs.asciidoctor.org/asciidoc/latest/lists/checklist/[Checklist] feature makes use of the _Ballet Box_ ☐ (U+2610) and _Ballot Box with Check_ "☑" (U+2611) characters.
-Two fonts provided by Windows, Segoe UI Symbol (`seguisym.ttf`) and Segoe UI Emoji (`seguiemj.ttf`), do contain these characters.
+xref:prepare-custom-font.adoc#modifying-the-font[Modifying the Font] lists all the characters required by Asciidoctor.
+
+Two fonts provided by Windows, Segoe UI Symbol [.path]_seguisym.ttf_ and Segoe UI Emoji [.path]_seguiemj.ttf_, are the only fonts provided by Windows which contain these characters.
 These two fonts have baselines which match better with most of the Windows font library than the default Notoserif font which is included with Asciidoctor PDF.
 
 Here is an example using Times New Roman with Segoe UI Symbol as a fallback providing the characters needed to support checklists:
@@ -117,6 +119,6 @@ font:
   - SegoeUISymbolFallback
 ----
 
-Make sure to configure the theme to include the location of the Windows font files, which is `c:\Windows\Fonts`.
+Make sure to configure the theme to include the location of the Windows font files, which is [.path]_c:\Windows\Fonts_.
 
 

--- a/docs/modules/theme/pages/fallback-font.adoc
+++ b/docs/modules/theme/pages/fallback-font.adoc
@@ -95,3 +95,23 @@ font:
 ----
 
 Now Asciidoctor PDF will look for the emoji in the Symbola font instead of the Noto Emoji font.
+
+== Default Microsoft Windows Font Limitations
+When using the fonts provided by default in Microsoft Windows 10, and possibly other versions, it is important to define a fallback font to provide full coverage of Asciidoctor language features.
+In particular, the https://docs.asciidoctor.org/asciidoc/latest/lists/checklist/[Checklist] feature makes use of the _Ballet Box_ ☐ (U+2610) and _Ballot Box with Check_ "☑" (U+2611) characters.
+Two fonts, Segoe UI Symbol (`seuisysm.ttf`) and Segoe UI Emoji (`seguiemj.ttf`), do contain these characters.
+
+Here is an example using Courier with Segoe UI Symbol as a fallback providing the characters needed to support checklists:
+[,yaml]
+----
+font:
+  catalog:
+    Courier:
+      normal: cour.ttf
+      italic: couri.ttf
+      bold: courbd.ttf
+      bold_italic: courbi.ttf
+    CourierFallback: seuisysm.ttf
+  fallbacks:
+  - CourierFallback
+----


### PR DESCRIPTION
Added "Default Microsoft Windows Font Limitations" which was discussed in [AsciiDoctor Zulipchat  - How to Find Glyphs to satisfy Font-Fallbacks for CustomTheme](https://asciidoctor.zulipchat.com/#narrow/stream/279727-tips-.F0.9F.92.A1/topic/How.20to.20Find.20Glyphs.20to.20satisfy.20Font-Fallbacks.20for.20CustomTheme).