### PR TITLE
Fix small typos in use-cases.adoc

### DIFF
--- a/docs/modules/extend/pages/use-cases.adoc
+++ b/docs/modules/extend/pages/use-cases.adoc
@@ -377,9 +377,9 @@ Asciidoctor PDF provides basic support for image floats.
 It will wrap paragraph text on the opposing side of the float.
 However, if it encounters a non-paragraph, the converter will clear the float and continue positioning content below the image.
 
-As a companion to this basics support, the converter provides a framework for broadening support for float wrapping.
+As a companion to this basic support, the converter provides a framework for broadening support for float wrapping.
 We can take advantage of this framework in an extended converter.
-By extending the converter and overriding the `supports_float_wrapping?` as well as the convert handler for the block you want to enlist (e.g., `convert_code`), you can arrange additional content into the empty space adjacent to the floated image.
+By extending the converter and overriding the `supports_float_wrapping?` method as well as the convert handler for the block you want to enlist (e.g., `convert_code`), you can arrange additional content into the empty space adjacent to the floated image.
 In the following example, code (listing and literal) blocks are included in the float wrapping.
 
 .Extended converter that additionally wraps code blocks around an image float


### PR DESCRIPTION
I think this reads more cleanly but captures the intent of the original text?