### PR TITLE
Add clarification about theming to attributes docs

### DIFF
--- a/docs/modules/ROOT/pages/asciidoc-attributes.adoc
+++ b/docs/modules/ROOT/pages/asciidoc-attributes.adoc
@@ -1,12 +1,9 @@
 = AsciiDoc Attributes for PDF
 
 Asciidoctor PDF supports additional built-in document attributes that impact PDF conversion.
-You can use these attributes to control the PDF media, launch mode, and outline, PDF optimization, text hyphenation, and various document-specific theme settings such as the front and back cover images, the background images, the title page logo and background images, page dimensions, and more.
+You can use these attributes to control the PDF media, launch mode, and outline, PDF optimization, text hyphenation, and various document-specific theme settings such as the front and back cover images, the background images, the title page logo and background images, page dimensions, and more. Some of these attributes overlap with settings controlled by the xref:theme:index.adoc[PDF theme].
 
-[NOTE]
-====
-The attributes mentioned on this page allow a limited configuration of the PDF output. For more options over the layout, you will have to xref:theme:create-theme.adoc#extend-default[extend] or create a new xref:theme:index.adoc[PDF theme] and xref:theme:apply-theme.adoc[apply] it to your document during processing.
-====
+These attributes are not meant to be a replacement for the theming system. Rather, they're provided as convenience to control some aspects of the theme that are often changed per document or conversion and thus warrant an override. For full control over the rendering of the PDF, you'll want to use a xref:theme:index.adoc[theme], which you can either create anew or xref:theme:create-theme.adoc#extend-default[extend from a built-in theme]. Once you have created a theme, you'll need to xref:theme:apply-theme.adoc[apply it] when converting the document.
 
 == AsciiDoc document attributes
 
@@ -145,8 +142,8 @@ If an attribute matches a key in the theme file, the document attribute takes pr
 |Yes
 |`:scripts: cjk`
 
-|xref:theme:text.adoc#text-align[text-align] ^[7]^
-|`center` {vbar} `justify` {vbar} `left` {vbar} `right` {vbar} `inherit`
+|`text-align`^[7]^
+|xref:theme:text.adoc#text-align[Text alignment]
 |Yes
 |`:text-align: left`
 

--- a/docs/modules/ROOT/pages/asciidoc-attributes.adoc
+++ b/docs/modules/ROOT/pages/asciidoc-attributes.adoc
@@ -3,16 +3,23 @@
 Asciidoctor PDF supports additional built-in document attributes that impact PDF conversion.
 You can use these attributes to control the PDF media, launch mode, and outline, PDF optimization, text hyphenation, and various document-specific theme settings such as the front and back cover images, the background images, the title page logo and background images, page dimensions, and more.
 
+[NOTE]
+====
+The attributes mentioned on this page allow a limited configuration of the PDF output. For more options over the layout, you will have to xref:theme:create-theme.adoc#extend-default[extend] or create a new xref:theme:index.adoc[PDF theme] and xref:theme:apply-theme.adoc[apply] it to your document during processing.
+====
+
 == AsciiDoc document attributes
 
-If an attribute is marked as "Header Only", it only takes effect if defined in the AsciiDoc document header or via the API.
+If an attribute is marked as "Header Only", it only takes effect if defined in the AsciiDoc document header.
+You can, however, add the attributes as parameters to your API or CLI calls.
+
 If an attribute matches a key in the theme file, the document attribute takes precedence.
 
 [cols="2,3,^1,6a"]
 |===
 |Attribute |Value Type |Header Only |Example
 
-|`autofit-option`
+|xref:autofit-text.adoc[autofit-option]
 |flag (default: _not set_)
 |No
 |`:autofit-option:`
@@ -53,7 +60,7 @@ If an attribute matches a key in the theme file, the document attribute takes pr
 |Yes
 |`:compress:`
 
-|`optimize`
+|xref:optimize-pdf.adoc[optimize]
 |`screen` {vbar} `ebook` {vbar} `printer` {vbar} `prepress` {vbar} `default` (default: `default`)
 |Yes
 |`:optimize: prepress`
@@ -138,8 +145,8 @@ If an attribute matches a key in the theme file, the document attribute takes pr
 |Yes
 |`:scripts: cjk`
 
-|`text-align`^[7]^
-|xref:theme:text.adoc#text-align[Text alignment]
+|xref:theme:text.adoc#text-align[text-align] ^[7]^
+|`center` {vbar} `justify` {vbar} `left` {vbar} `right` {vbar} `inherit`
 |Yes
 |`:text-align: left`
 

--- a/docs/modules/ROOT/pages/optimize-pdf.adoc
+++ b/docs/modules/ROOT/pages/optimize-pdf.adoc
@@ -43,6 +43,7 @@ Otherwise, run the command in the *gem command* column.
 |gem install rghost
 |===
 
+[#optimize]
 === Convert and optimize
 
 Here's an example usage that converts your document and optimizes it:


### PR DESCRIPTION
According to this discussion, add some clarifications and some minor adjustments to the PDF attributes docs.

I've also added some missing xrefs to the attributes list. I can't really verify if the links work right since I don't know to test the Antora deployment. Sorry :/

https://asciidoctor.zulipchat.com/#narrow/stream/288690-users.2Fasciidoctor-pdf/topic/Self-contained.20adoc.2C.20including.20theme.20configuration.3F