### PR TITLE
resolves #2502 propagate source location to table cell for description in horizontal dlist

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -53,6 +53,7 @@ Bug Fixes::
 * prevent special character substitution from interfering with callouts in plain verbatim block (#2390)
 * remove deprecated, undocumented `svg-font-family` theme key (the correct key is `svg-fallback-font-family`)
 * major improvement to OTF support following release of ttfunk 1.8.0 (automatic transitive dependency of prawn)
+* propagate source location to table cell for description in horizontal dlist so it is included in truncation warning message (#2502)
 * upgrade prawn-svg to 0.34 to fix warning about base64 gem when using Ruby >= 3.3; apply additional patch to fix bug in prawn-svg
 
 == 2.3.13 (2024-02-16) - @mojavelinux

--- a/lib/asciidoctor/pdf/converter.rb
+++ b/lib/asciidoctor/pdf/converter.rb
@@ -1475,7 +1475,7 @@ module Asciidoctor
               desc_container = Block.new node, :open
               desc_container << (Block.new desc_container, :paragraph, source: (desc.instance_variable_get :@text), subs: :default) if desc.text?
               desc.blocks.each {|b| desc_container << b.dup } if desc.blocks?
-              row_data << { content: (::Prawn::Table::Cell::AsciiDoc.new self, content: (item[1] = desc_container), text_color: @font_color, padding: desc_padding, valign: :top) }
+              row_data << { content: (::Prawn::Table::Cell::AsciiDoc.new self, content: (item[1] = desc_container), text_color: @font_color, padding: desc_padding, valign: :top, source_location: desc.source_location) }
             else
               row_data << {}
             end

--- a/spec/list_spec.rb
+++ b/spec/list_spec.rb
@@ -1500,6 +1500,19 @@ describe 'Asciidoctor::PDF::Converter - List' do
           (expect texts[0][:y].round 2).to eql (texts[1][:y].round 2)
         end
       end
+
+      it 'should report source location of truncated item description in dlist' do
+        (expect do
+          pdf = to_pdf <<~END, sourcemap: true, attribute_overrides: { 'docfile' => 'test.adoc' }, analyze: true
+          [horizontal]
+          step 1::
+          #{['* task'] * 50 * ?\n}
+          END
+
+          (expect pdf.pages.size).to eql 1
+          (expect (pdf.find_unique_text 'step 1')).not_to be_nil
+        end).to log_message severity: :ERROR, message: 'the table cell on page 1 has been truncated; Asciidoctor PDF does not support table cell content that exceeds the height of a single page', file: 'test.adoc', lineno: 3
+      end
     end
 
     context 'Unordered' do

--- a/spec/spec_helper/matchers/have_message.rb
+++ b/spec/spec_helper/matchers/have_message.rb
@@ -27,8 +27,8 @@ RSpec::Matchers.define :have_message do |expected|
         elsif message_text === expected_message
           result = true
         end
-        result = false if (file = expected[:file]) && !(Hash === message_data && file == message_data[:source_location].file)
-        result = false if (lineno = expected[:lineno]) && !(Hash === message_data && lineno == message_data[:source_location].lineno)
+        result = false if (file = expected[:file]) && !(Hash === message_data && file == message_data[:source_location]&.file)
+        result = false if (lineno = expected[:lineno]) && !(Hash === message_data && lineno == message_data[:source_location]&.lineno)
       end
       actual = message
     end


### PR DESCRIPTION
source location is used in truncation warning message