### PR TITLE
resolves #2521 don't hyphenate autolink when hyphenation is enabled

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -39,6 +39,7 @@ Improvements::
 * drop support for the unmaintained payment font (`pf`) for use in font-based icons
 * refactor formatted text transform to simplify how inner space is collapsed; verify only inner hard breaks are preserved
 * allow relative font size for sub and sup to be set independently; support combined setting for backwards compatibility
+* don't hyphenate autolink when hyphenation is enabled (#2521) (*@meonkeys*)
 
 Bug Fixes::
 

--- a/spec/hyphens_spec.rb
+++ b/spec/hyphens_spec.rb
@@ -215,6 +215,18 @@ describe 'Asciidoctor::PDF::Converter - Hyphens', if: (RSpec::ExampleGroupHelper
     (expect lines[1]).to eql 'graph'
   end
 
+  it 'should not hyphenate URL of autolink' do
+    pdf = to_pdf <<~'END', analyze: true
+    :hyphens:
+
+    https://pellentesqueullamcorperpellentesqueullamcorperconsecteturviverrascelerisque.example.com
+    END
+
+    lines = pdf.lines
+    (expect lines.size).to be > 1
+    (expect lines[0]).not_to end_with ?\u00ad
+  end
+
   it 'should show visible hyphen at locate where word is split across lines', visual: true do
     to_file = to_pdf_file <<~'END', 'hyphens-word-break.pdf'
     :hyphens:


### PR DESCRIPTION
(see commit log message for details, including caveats)

(sorry about the force push, I won't do any more of those)