### PR TITLE
Update prawn-icon to version 4.1.0

### DIFF
--- a/asciidoctor-pdf.gemspec
+++ b/asciidoctor-pdf.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'prawn-table', '~> 0.2.0'
   s.add_runtime_dependency 'prawn-templates', '~> 0.1.0'
   s.add_runtime_dependency 'prawn-svg', '~> 0.34.0'
-  s.add_runtime_dependency 'prawn-icon', '~> 3.0.0'
+  s.add_runtime_dependency 'prawn-icon', '~> 4.1.0'
   s.add_runtime_dependency 'concurrent-ruby', '~> 1.1'
   s.add_runtime_dependency 'treetop', '~> 1.6.0'
 

--- a/lib/asciidoctor/pdf/converter.rb
+++ b/lib/asciidoctor/pdf/converter.rb
@@ -955,7 +955,8 @@ module Asciidoctor
                       valign: label_valign,
                       align: label_text_align,
                       color: (icon_data[:stroke_color] || font_color),
-                      size: icon_size
+                      size: icon_size,
+                      size_mode: :icon_height
                   elsif icons
                     if (::Asciidoctor::Image.format icon_path) == 'svg'
                       begin

--- a/spec/admonition_spec.rb
+++ b/spec/admonition_spec.rb
@@ -428,7 +428,7 @@ describe 'Asciidoctor::PDF::Converter - Admonition' do
       (expect text).to have_size 2
       label_text = text[0]
       (expect label_text[:string]).to eql ?\uf0eb
-      (expect label_text[:font_name]).to eql 'FontAwesome5Free-Regular'
+      (expect label_text[:font_name]).to eql 'FontAwesome6Free-Regular'
       # NOTE: font size is reduced to fit within available space
       (expect label_text[:font_size]).to be < 24
       content_text = text[1]
@@ -448,7 +448,7 @@ describe 'Asciidoctor::PDF::Converter - Admonition' do
       EOS
 
       label_text = pdf.find_unique_text ?\uf06a
-      (expect label_text[:font_size]).to eql 50
+      (expect label_text[:font_size]).to be_within(0.0001).of(47.98464)
     end
 
     it 'should allow the theme to specify a minimum width for the font-based icon label' do
@@ -509,7 +509,7 @@ describe 'Asciidoctor::PDF::Converter - Admonition' do
       EOS
 
       icon_text = pdf.text[0]
-      (expect icon_text[:font_name]).to eql 'FontAwesome5Free-Solid'
+      (expect icon_text[:font_name]).to eql 'FontAwesome6Free-Solid'
       (expect icon_text[:string]).to eql ?\uf4da
     end
 
@@ -522,7 +522,7 @@ describe 'Asciidoctor::PDF::Converter - Admonition' do
         EOS
 
         icon_text = pdf.text[0]
-        (expect icon_text[:font_name]).to eql 'FontAwesome5Free-Solid'
+        (expect icon_text[:font_name]).to eql 'FontAwesome6Free-Solid'
         (expect icon_text[:string]).to eql ?\uf4da
       end).to log_message severity: :INFO, message: 'tip admonition in theme uses icon from deprecated fa icon set; use fas, far, or fab instead', using_log_level: :INFO
     end
@@ -547,7 +547,7 @@ describe 'Asciidoctor::PDF::Converter - Admonition' do
       EOS
 
       icon_text = pdf.text[0]
-      (expect icon_text[:font_name]).to eql 'FontAwesome5Free-Solid'
+      (expect icon_text[:font_name]).to eql 'FontAwesome6Free-Solid'
       (expect icon_text[:string]).to eql ?\uf05a
     end
 
@@ -576,7 +576,7 @@ describe 'Asciidoctor::PDF::Converter - Admonition' do
       (expect text).to have_size 2
       label_text = text[0]
       (expect label_text[:string]).to eql ?\uf3d1
-      (expect label_text[:font_name]).to eql 'FontAwesome5Free-Regular'
+      (expect label_text[:font_name]).to eql 'FontAwesome6Free-Regular'
       content_text = text[1]
       (expect content_text[:string]).to eql 'Look for the warp zone under the bridge.'
     end
@@ -1050,8 +1050,8 @@ describe 'Asciidoctor::PDF::Converter - Admonition' do
 
       icon_text = pdf.find_unique_text ?\uf059
       (expect icon_text).not_to be_nil
-      (expect icon_text[:font_name]).to eql 'FontAwesome5Free-Solid'
-      (expect icon_text[:font_size]).to be 24
+      (expect icon_text[:font_name]).to eql 'FontAwesome6Free-Solid'
+      (expect icon_text[:font_size]).to be_within(0.0001).of(23.03263)
       (expect pdf.find_unique_text 'Are you following along?').not_to be_nil
       (expect pdf.find_unique_text 'Just checking ;)').not_to be_nil
     end

--- a/spec/audio_spec.rb
+++ b/spec/audio_spec.rb
@@ -42,7 +42,7 @@ describe 'Asciidoctor::PDF::Converter - Audio' do
 
     icon_text = (pdf.find_text ?\uf04b)[0]
     (expect icon_text).not_to be_nil
-    (expect icon_text[:font_name]).to eql 'FontAwesome5Free-Solid'
+    (expect icon_text[:font_name]).to eql 'FontAwesome6Free-Solid'
   end
 
   it 'should show caption for audio if title is specified' do

--- a/spec/icon_spec.rb
+++ b/spec/icon_spec.rb
@@ -54,7 +54,7 @@ describe 'Asciidoctor::PDF::Converter - Icon' do
     EOS
     wink_text = pdf.find_text ?\uf0ad
     (expect wink_text).to have_size 1
-    (expect wink_text[0][:font_name]).to eql 'FontAwesome5Free-Solid'
+    (expect wink_text[0][:font_name]).to eql 'FontAwesome6Free-Solid'
   end
 
   it 'should support icon set as suffix on icon name' do
@@ -65,7 +65,7 @@ describe 'Asciidoctor::PDF::Converter - Icon' do
     EOS
     wink_text = pdf.find_text ?\uf0ad
     (expect wink_text).to have_size 1
-    (expect wink_text[0][:font_name]).to eql 'FontAwesome5Free-Solid'
+    (expect wink_text[0][:font_name]).to eql 'FontAwesome6Free-Solid'
   end
 
   it 'should support icon set as prefix on icon name' do
@@ -76,7 +76,7 @@ describe 'Asciidoctor::PDF::Converter - Icon' do
     EOS
     wink_text = pdf.find_text ?\uf0ad
     (expect wink_text).to have_size 1
-    (expect wink_text[0][:font_name]).to eql 'FontAwesome5Free-Solid'
+    (expect wink_text[0][:font_name]).to eql 'FontAwesome6Free-Solid'
   end
 
   it 'should support icon set as prefix on icon name even if icon set is configured globally' do
@@ -88,7 +88,7 @@ describe 'Asciidoctor::PDF::Converter - Icon' do
     EOS
     wink_text = pdf.find_text ?\uf0ad
     (expect wink_text).to have_size 1
-    (expect wink_text[0][:font_name]).to eql 'FontAwesome5Free-Solid'
+    (expect wink_text[0][:font_name]).to eql 'FontAwesome6Free-Solid'
   end
 
   it 'should not support icon set as prefix on icon name if explicit icon set is specified' do
@@ -191,7 +191,7 @@ describe 'Asciidoctor::PDF::Converter - Icon' do
       EOS
       hdd_text = pdf.find_text ?\uf0a0
       (expect hdd_text).to have_size 1
-      (expect hdd_text[0][:font_name]).to eql 'FontAwesome5Free-Regular'
+      (expect hdd_text[0][:font_name]).to eql 'FontAwesome6Free-Regular'
     end).to log_message severity: :INFO, message: 'hdd-o icon found in deprecated fa icon set; using hdd from far icon set instead', using_log_level: :INFO
   end
 
@@ -204,7 +204,7 @@ describe 'Asciidoctor::PDF::Converter - Icon' do
       EOS
       wink_text = pdf.find_text ?\uf4da
       (expect wink_text).to have_size 1
-      (expect wink_text[0][:font_name]).to eql 'FontAwesome5Free-Regular'
+      (expect wink_text[0][:font_name]).to eql 'FontAwesome6Free-Regular'
     end).to log_message severity: :INFO, message: 'smile-wink icon not found in deprecated fa icon set; using match found in far icon set instead', using_log_level: :INFO
   end
 
@@ -225,7 +225,7 @@ describe 'Asciidoctor::PDF::Converter - Icon' do
     pdf = to_pdf input, analyze: true
     link_text = (pdf.find_text ?\uf019)[0]
     (expect link_text).not_to be_nil
-    (expect link_text[:font_name]).to eql 'FontAwesome5Free-Solid'
+    (expect link_text[:font_name]).to eql 'FontAwesome6Free-Solid'
     (expect link_text[:font_color]).to eql '428BCA'
     link_text[:font_size] -= 1.5 # box appox is a little off
     (expect link_annotation).to annotate link_text
@@ -259,7 +259,7 @@ describe 'Asciidoctor::PDF::Converter - Icon' do
 
     heart_text = pdf.text[0]
     (expect heart_text[:string]).to eql ?\uf004
-    (expect heart_text[:font_name]).to eql 'FontAwesome5Free-Regular'
+    (expect heart_text[:font_name]).to eql 'FontAwesome6Free-Regular'
     (expect heart_text[:font_color]).to eql 'FF0000'
   end
 
@@ -278,6 +278,6 @@ describe 'Asciidoctor::PDF::Converter - Icon' do
     (expect keyseq_text[0][:font_name]).to eql 'mplus1mn-regular'
     (expect keyseq_text[1][:string]).to eql %(\u202f+\u202f)
     (expect keyseq_text[2][:string]).to eql ?\uf062
-    (expect keyseq_text[2][:font_name]).to eql 'FontAwesome5Free-Solid'
+    (expect keyseq_text[2][:font_name]).to eql 'FontAwesome6Free-Solid'
   end
 end

--- a/spec/list_spec.rb
+++ b/spec/list_spec.rb
@@ -302,7 +302,7 @@ describe 'Asciidoctor::PDF::Converter - List' do
         (expect pdf.lines).to eql [%(\uf192 bullseye!)]
         marker_text = pdf.find_unique_text ?\uf192
         (expect marker_text).not_to be_nil
-        (expect marker_text[:font_name]).to eql 'FontAwesome5Free-Regular'
+        (expect marker_text[:font_name]).to eql 'FontAwesome6Free-Regular'
       end
     end
 
@@ -541,10 +541,10 @@ describe 'Asciidoctor::PDF::Converter - List' do
         (expect pdf.lines).to eql [%(\uf096 todo), %(\uf046 done)]
         unchecked_marker_text = pdf.find_unique_text ?\uf096
         (expect unchecked_marker_text).not_to be_nil
-        (expect unchecked_marker_text[:font_name]).to eql 'FontAwesome5Free-Solid'
+        (expect unchecked_marker_text[:font_name]).to eql 'FontAwesome6Free-Solid'
         checked_marker_text = pdf.find_unique_text ?\uf046
         (expect checked_marker_text).not_to be_nil
-        (expect checked_marker_text[:font_name]).to eql 'FontAwesome5Free-Solid'
+        (expect checked_marker_text[:font_name]).to eql 'FontAwesome6Free-Solid'
       end
     end
   end


### PR DESCRIPTION
This PR updates prawn-icon to v4.1.0

The main change in 4.1.0 is the upgrade of Font Awesome to v6. An extra feature has been added that allows to keep the icon size consistent even though the font metrics of FAv6 are a bit different to those of v5.

There are still two failing visual comparison tests. I wasn't sure if I could just update the reference. FWIW, the computer sees a difference, my eyes don't.