### PR TITLE
resolves #2576 add theming support for size, family, and style in horizontal dlist blocks

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -41,6 +41,7 @@ Improvements::
 * allow relative font size for sub and sup to be set independently; support combined setting for backwards compatibility
 * allow value of `base-font-size-min` and `<category>-font-size-min` theme keys to be relative (e.g., 0.75em) (#2547)
 * upgrade prawn-svg to 0.36 to fix dependencies, improve gradient support, and support additional properties; disable experimental warnings when requiring prawn-svg on Ruby 2.7 (#2551)
+* honor font size, family, and style on term of horizontal dlist (#2567)
 
 Bug Fixes::
 

--- a/lib/asciidoctor/pdf/converter.rb
+++ b/lib/asciidoctor/pdf/converter.rb
@@ -1441,6 +1441,9 @@ module Asciidoctor
           table_data = []
           term_padding = term_padding_no_blocks = term_font_color = term_transform = desc_padding = term_line_metrics = term_inline_format = term_kerning = nil
           max_term_width = 0
+          term_font_size = @theme.description_list_term_font_size
+          term_font_family = @theme.description_list_term_font_family
+          term_font_style = @theme.description_list_term_font_style
           theme_font :description_list_term do
             term_font_color = @font_color
             term_transform = @text_transform
@@ -1484,6 +1487,7 @@ module Asciidoctor
           term_column_width = [max_term_width, bounds.width * 0.5].min
           table table_data, position: :left, column_widths: [term_column_width] do
             cells.style border_width: 0
+            column(0).style size: term_font_size, font: term_font_family, style: term_font_style
             @pdf.ink_table_caption node if node.title?
           end
           theme_margin :prose, :bottom, (next_enclosed_block actual_node) #unless actual_node.nested?


### PR DESCRIPTION
This PR adds support term-font-size, term-font-family, and term-font-style to description lists with the [horizontal] style.
It does so by applying them to the first column, column(0) of the prawn table.

https://asciidoctor.zulipchat.com/#narrow/channel/288690-users.2Fasciidoctor-pdf/topic/Term.20keys.20only.20modify.20vertical.20description.20lists/with/526527497
