### PR TITLE
add support for alt section titles in outline and bookmarks

### DIFF
--- a/lib/asciidoctor/pdf/converter.rb
+++ b/lib/asciidoctor/pdf/converter.rb
@@ -2908,7 +2908,7 @@ module Asciidoctor
         sections.each do |sect|
           next if (num_levels_for_sect = (sect.attr 'outlinelevels', num_levels).to_i) < (level = sect.level) ||
             ((sect.option? 'notitle') && sect == sect.document.last_child && sect.empty?)
-          sect_title = sanitize sect.numbered_title formal: true
+          sect_title = sanitize sect.numbered_title formal: true, toc: true
           next if sect_title.empty?
           sect_destination = sect.attr 'pdf-destination'
           if level < num_levels_for_sect && sect.sections?
@@ -4052,7 +4052,7 @@ module Asciidoctor
         entries.each do |entry|
           next if (num_levels_for_entry = (entry.attr 'toclevels', num_levels).to_i) < (entry_level = entry.level + 1).pred ||
             ((entry.option? 'notitle') && entry == entry.document.last_child && entry.empty?)
-          entry_title = entry.context == :section ? entry.numbered_title : (entry.title? ? entry.title : (entry.xreftext 'basic'))
+          entry_title = entry.context == :section ? entry.numbered_title(toc: true) : (entry.title? ? entry.title : (entry.xreftext 'basic'))
           next if entry_title.empty?
           theme_font :toc, level: entry_level do
             entry_title = entry_title.gsub DropAnchorRx, '' if entry_title.include? '<a'
@@ -5049,7 +5049,7 @@ module Asciidoctor
 
       def generate_manname_section node
         title = node.attr 'manname-title', 'Name'
-        if (next_section_title = node.sections[0]&.title) && next_section_title.upcase == next_section_title
+        if (next_section_title = node.sections[0]&.toc_title) && next_section_title.upcase == next_section_title
           title = title.upcase
         end
         sect = Section.new node, 1

--- a/lib/asciidoctor/pdf/ext/asciidoctor/section.rb
+++ b/lib/asciidoctor/pdf/ext/asciidoctor/section.rb
@@ -2,36 +2,41 @@
 
 Asciidoctor::Section.prepend (Module.new do
   def numbered_title opts = {}
-    @cached_numbered_title ||= nil
-    unless @cached_numbered_title
+    idx = opts[:toc] ? 1 : 0
+    stitle = opts[:toc] ? toc_title : title
+    @cached_numbered_title ||= Array.new(2)
+    @cached_formal_numbered_title ||= Array.new(2)
+    unless @cached_numbered_title[idx]
       doc = @document
       if @numbered && !@caption && (slevel = @level) <= (doc.attr 'sectnumlevels', 3).to_i
         @is_numbered = true
         if doc.doctype == 'book'
           case slevel
           when 0
-            @cached_numbered_title = %(#{sectnum nil, ':'} #{title})
+            numbered_title = %(#{sectnum nil, ':'} #{stitle})
             signifier = doc.attributes['part-signifier'] || ((doc.attr_unspecified? 'part-signifier') ? 'Part' : '')
-            @cached_formal_numbered_title = %(#{signifier}#{signifier.empty? ? '' : ' '}#{@cached_numbered_title})
+            formal_numbered_title = %(#{signifier}#{signifier.empty? ? '' : ' '}#{numbered_title})
           when 1
-            @cached_numbered_title = %(#{sectnum} #{title})
+            numbered_title = %(#{sectnum} #{stitle})
             signifier = doc.attributes['chapter-signifier'] || ((doc.attr_unspecified? 'chapter-signifier') ? 'Chapter' : '')
-            @cached_formal_numbered_title = %(#{signifier}#{signifier.empty? ? '' : ' '}#{@cached_numbered_title})
+            formal_numbered_title = %(#{signifier}#{signifier.empty? ? '' : ' '}#{numbered_title})
           else
-            @cached_formal_numbered_title = @cached_numbered_title = %(#{sectnum} #{title})
+            formal_numbered_title = numbered_title = %(#{sectnum} #{stitle})
           end
         else
-          @cached_formal_numbered_title = @cached_numbered_title = %(#{sectnum} #{title})
+          formal_numbered_title = numbered_title = %(#{sectnum} #{stitle})
         end
       elsif @level == 0
         @is_numbered = false
-        @cached_numbered_title = @cached_formal_numbered_title = title
+        numbered_title = formal_numbered_title = stitle
       else
         @is_numbered = false
-        @cached_numbered_title = @cached_formal_numbered_title = captioned_title
+        numbered_title = formal_numbered_title = opts[:toc] ? captioned_toc_title : captioned_title
       end
+      @cached_numbered_title[idx] = numbered_title
+      @cached_formal_numbered_title[idx] = formal_numbered_title
     end
-    opts[:formal] ? @cached_formal_numbered_title : @cached_numbered_title
+    opts[:formal] ? @cached_formal_numbered_title[idx] : @cached_numbered_title[idx]
   end
 
   def first_section_of_part?


### PR DESCRIPTION
These are the adjustments needed for making short/alternative section titles work as the feature proposed in https://github.com/asciidoctor/asciidoctor/pull/4845 and hence the code here depends on that to be merged.