### PR TITLE
docs: fix separated spelling in docs

### DIFF
--- a/docs/modules/theme/pages/running-content.adoc
+++ b/docs/modules/theme/pages/running-content.adoc
@@ -473,7 +473,7 @@ To make the background color, background image, and border span the width of the
 == columns
 
 The `columns` key is used to define the number of columns, the named position of those columns, as well as each column's width and alignment.
-The columns are defined using space-seprated (or comma-seperated) colspecs.
+The columns are defined using space-seprated (or comma-separated) colspecs.
 The maximum number of columns is 3.
 The column's name is infered by the position of the colspec in the list (center for 1 column, left and right for 2 columns, and left, center, and right for 3 columns).
 


### PR DESCRIPTION
Changes:
- `seperated` -> `separated` in `docs/modules/theme/pages/running-content.adoc` (1 occurrence(s), preserving capitalization where applicable)

Verification:
- Applied an exact spelling-only replacement against the current upstream base branch.
- Checked the repository is not archived or a fork.
- Checked open PR titles and my open PRs before opening this PR.
