### PR TITLE
Fix dead cross-references to discrete headings / inline anchors with non-ASCII IDs

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -55,6 +55,7 @@ Bug Fixes::
 * prevent special character substitution from interfering with callouts in plain verbatim block (#2390)
 * remove deprecated, undocumented `svg-font-family` theme key (the correct key is `svg-fallback-font-family`)
 * major improvement to OTF support following release of ttfunk 1.8.0 (automatic transitive dependency of prawn)
+* fix dead cross-reference to discrete heading or inline anchor with ID that contains non-ASCII characters by registering destination name using same hex encoding used by reference (#2646)
 
 Compliance::
 

--- a/lib/asciidoctor/pdf/converter.rb
+++ b/lib/asciidoctor/pdf/converter.rb
@@ -2530,7 +2530,7 @@ module Asciidoctor
         target = node.target
         case node.type
         when :link
-          anchor = node.id ? %(<a id="#{node.id}">#{DummyText}</a>) : ''
+          anchor = node.id ? %(<a id="#{derive_anchor_from_id node.id}">#{DummyText}</a>) : ''
           class_attr = ''
           if (role = node.role)
             class_attr = %( class="#{role}")
@@ -2578,14 +2578,14 @@ module Asciidoctor
           end
         when :ref
           # NOTE: destination is created inside callback registered by FormattedTextTransform#build_fragment
-          %(<a id="#{node.id}">#{DummyText}</a>)
+          %(<a id="#{derive_anchor_from_id node.id}">#{DummyText}</a>)
         when :bibref
           id = node.id
           # NOTE: technically node.text should be node.reftext, but subs have already been applied to text
           reftext = (reftext = node.reftext) ? %([#{reftext}]) : %([#{id}])
           reftext = %(<a anchor="_bibref_ref_#{id}">#{reftext}</a>) if @bibref_refs.include? id
           # NOTE: destination is created inside callback registered by FormattedTextTransform#build_fragment
-          %(<a id="#{id}">#{DummyText}</a>#{reftext})
+          %(<a id="#{derive_anchor_from_id id}">#{DummyText}</a>#{reftext})
         else
           log :warn, %(unknown anchor type: #{node.type.inspect})
           nil
@@ -2827,7 +2827,7 @@ module Asciidoctor
         end
 
         # NOTE: destination is created inside callback registered by FormattedTextTransform#build_fragment
-        node.id ? %(<a id="#{node.id}">#{DummyText}</a>#{quoted_text}) : quoted_text
+        node.id ? %(<a id="#{derive_anchor_from_id node.id}">#{DummyText}</a>#{quoted_text}) : quoted_text
       end
 
       # If an id is provided or the node passed as the first argument has an id,
@@ -2851,7 +2851,8 @@ module Asciidoctor
           end
           # TODO: find a way to store only the ref of the destination; look it up when we need it
           node.set_attr 'pdf-destination', (node_dest = (dest_xyz dest_x, dest_y))
-          add_dest id, node_dest
+          # NOTE: derive the destination name the same way references do so non-ASCII IDs match (see #308)
+          add_dest (derive_anchor_from_id id), node_dest
         end
         nil
       end

--- a/spec/xref_spec.rb
+++ b/spec/xref_spec.rb
@@ -104,6 +104,37 @@ describe 'Asciidoctor::PDF::Converter - Xref' do
       (expect (pdf.page 1).text).to include 'See Über Étudier.'
     end
 
+    it 'should reference discrete heading with ID that contains non-ASCII characters' do
+      pdf = to_pdf <<~'END'
+      See <<disc_дискрет>>.
+
+      [discrete#disc_дискрет]
+      == Дискретный заголовок
+      END
+
+      hex_encoded_id = %(0x#{('disc_дискрет'.unpack 'H*')[0]})
+      (expect get_names pdf).to have_key hex_encoded_id
+      annotations = get_annotations pdf, 1
+      (expect annotations).to have_size 1
+      (expect annotations[0][:Dest]).to eql hex_encoded_id
+    end
+
+    it 'should reference inline anchor with ID that contains non-ASCII characters' do
+      ['[[ref_ссылка]]The target.', '[#ref_ссылка]#The target#'].each do |target|
+        pdf = to_pdf <<~END
+        See <<ref_ссылка>>.
+
+        #{target}
+        END
+
+        hex_encoded_id = %(0x#{('ref_ссылка'.unpack 'H*')[0]})
+        (expect get_names pdf).to have_key hex_encoded_id
+        annotations = get_annotations pdf, 1
+        (expect annotations).to have_size 1
+        (expect annotations[0][:Dest]).to eql hex_encoded_id
+      end
+    end
+
     it 'should create reference to a block by explicit ID' do
       pdf = to_pdf <<~'END'
       = Document Title


### PR DESCRIPTION
Fixes #2646

## What this fixes

Cross-references to a `[discrete]` heading — or to an inline/phrase anchor (`[[id]]`, `anchor:id[]`,
`[#id]#text#`) — whose **ID contains characters outside Windows-1252** (e.g. Cyrillic) produced
**dead links** in the PDF. References to regular section headings (`==`, `===`) with the same kind of
ID already worked.

The cause is an asymmetry left behind by #308:

- **References** encode the destination name with `derive_anchor_from_id`, which returns
  `0x<utf8-hex>` for any value that is not `ascii_only?` (the `:xref` case uses
  `<a anchor="#{derive_anchor_from_id refid}">`).
- **Sections** register their destination with the *same* derived name (`convert_section` calls
  `derive_anchor_from_id sect.id` and passes the result to `add_dest_for_block`), so they match.
- **Block destinations** (`add_dest_for_block`) and **inline-anchor destinations**
  (`convert_inline_anchor` / `convert_inline_quoted`, registered by
  `InlineDestinationMarker.render_behind`) registered the **raw** id instead.

For a non-ASCII id this means: registration = raw UTF-8 bytes, reference = `0x<utf8-hex>` → the names
don't match → dead link.

## The change

Route destination *registration* through the same `derive_anchor_from_id` that *references* already
use, at the points where the destination name is emitted:

| Location | Path |
| --- | --- |
| `add_dest_for_block` | all block destinations (covers `[discrete]` headings via `convert_floating_title`, and any block with a non-ASCII explicit id) |
| `convert_inline_anchor` — `:link` | inline link with `id=` |
| `convert_inline_anchor` — `:ref` | inline anchor (`[[id]]`, `anchor:id[]`) |
| `convert_inline_anchor` — `:bibref` | bibliography anchor (`[[[id]]]`) |
| `convert_inline_quoted` | phrase anchor (`[#id]#text#`) |

`derive_anchor_from_id` is **idempotent** for values that are already derived or ASCII-only (it returns
them unchanged), so this is a no-op for everything that already worked — sections (already derived),
`toc`, `pdf-anchor`, and every ASCII id. Only non-ASCII block/inline anchor names change, which is
exactly the broken case.

Internal, raw-on-both-sides destination names are deliberately **left untouched** so they keep
matching their (also raw) references: the `_bibref_ref_` citation backlinks, the `_footnoteref_` /
`_footnotedef_` footnote backlinks (integer-suffixed, always ASCII anyway), and index-term anchors
(registered raw and looked up raw by the index).

> Note on scope: the issue describes `[discrete]` headings and `[[id]]` / `anchor:id[]` anchors. The
> fix also covers the phrase anchor `[#id]#text#` (`convert_inline_quoted`), because it shares the
> identical root cause and the existing dest spec already treats `[[details]]` and `[#details]#details#`
> as equivalent inline-anchor forms. If you'd prefer to keep the PR strictly scoped, that one line can
> be dropped — but the bug is present there too.

## Tests

Added two specs in `spec/xref_spec.rb`, next to the existing
`should reference section with ID that contains non-ASCII characters` example:

- `should reference discrete heading with ID that contains non-ASCII characters`
- `should reference inline anchor with ID that contains non-ASCII characters` (covers both
  `[[id]]` and `[#id]#text#` forms)

Each asserts that the registered destination name **and** the link annotation's `/Dest` are both the
hex-encoded id, i.e. they match. Both specs **fail before** this change (the destination is registered
under the raw-bytes key) and **pass after**.


## CHANGELOG

Added an entry under `== Unreleased` → `Bug Fixes::` in `CHANGELOG.adoc`.